### PR TITLE
Chore: android permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/launcherBaseTheme">
 
-        <activity android:name=".HomeActivity"
+        <activity
+            android:name=".HomeActivity"
             android:exported="true"
             android:excludeFromRecents="true"
             android:clearTaskOnLaunch="true"
@@ -30,16 +31,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".tutorial.TutorialActivity"
+        <activity
+            android:name=".tutorial.TutorialActivity"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity">
         </activity>
-        <activity android:name=".list.ListActivity"
+        <activity
+            android:name=".list.ListActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity">
         </activity>
-        <activity android:name=".settings.SettingsActivity"
+        <activity
+            android:name=".settings.SettingsActivity"
             android:exported="true"
             android:permission="android.permission.MANAGE_APP_PERMISSIONS"
             android:screenOrientation="portrait"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
@@ -42,6 +41,7 @@
         </activity>
         <activity android:name=".settings.SettingsActivity"
             android:exported="true"
+            android:permission="android.permission.REQUEST_DELETE_PACKAGES"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
         </activity>
         <activity android:name=".settings.SettingsActivity"
             android:exported="true"
-            android:permission="android.permission.REQUEST_DELETE_PACKAGES"
+            android:permission="android.permission.MANAGE_APP_PERMISSIONS"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity">
             <intent-filter>


### PR DESCRIPTION
Modifications :
- Since Android 11 it is not necessary to ask for `WRITE_EXTERNAL_STORAGE` and since Android 13 it is deprecated 
- Let Android studio reformat the file as he wanted
- Added a permission to the exported field of settings to prevent any app from calling the launcher's settings (the exact permission can be discussed if you think of a more appropriate one)