### PR TITLE
Fix: accessbility service `isEnabled()` always return false

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,7 +247,7 @@
     <string name="device_admin_description">Enable the lock screen action</string>
     <string name="alert_no_torch_found">No camera with torch detected.</string>
     <string name="alert_torch_access_exception">Error: Can\'t access torch.</string>
-    <string name="alert_lock_screen_failed">Error: Failed to lock screen.</string>
+    <string name="alert_lock_screen_failed">Error: Failed to lock screen. (if you just upgraded/reinstalled the app, try to disable and re-enable the accessibility service in phone settings)</string>
     <string name="toast_accessibility_service_not_enabled">μLauncher\'s accessibility service is not enabled. Please enable it in settings</string>
     <string name="toast_lock_screen_not_supported">Error: Locking the screen using accessibility is not supported on this device. Please use device admin instead.</string>
     <string name="accessibility_service_name">µLauncher - lock screen</string>


### PR DESCRIPTION
Since our `android:accessibilityEventTypes` is unspecified intentionally, the `accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)` method can't list out our service.

Therefore, I use `Settings.Secure.getString()` instead.

---

Another thing, I've noticed that on my device, after reinstalling the app, the app's accessibility service gets disabled (which is as expected), but after re-enabling the service in System Settings. `Settings.Secure.getString()` tells me that it's successfully enabled, but actually `performGlobalAction()` fails. Need to disable and re-enable the service again for it to work.

I don't know why, I'm put a tip in the `alert_lock_screen_failed` toast.