### PR TITLE
feat: Add option to hide navigation bar on home screen

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -59,9 +59,9 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 }),
                 @PreferenceGroup(name = "display", prefix = "settings_display_", suffix = "_key", value = {
                         @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "full_screen", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "rotate_screen", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "hide_status_bar", type = boolean.class, defaultValue = "true"),
                         @Preference(name = "hide_navigation_bar", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "rotate_screen", type = boolean.class, defaultValue = "true"),
                 }),
                 @PreferenceGroup(name = "functionality", prefix = "settings_functionality_", suffix = "_key", value = {
                         @Preference(name = "search_auto_launch", type = boolean.class, defaultValue = "true"),

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -61,6 +61,7 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "full_screen", type = boolean.class, defaultValue = "true"),
                         @Preference(name = "rotate_screen", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "hide_navigation_bar", type = boolean.class, defaultValue = "false"),
                 }),
                 @PreferenceGroup(name = "functionality", prefix = "settings_functionality_", suffix = "_key", value = {
                         @Preference(name = "search_auto_launch", type = boolean.class, defaultValue = "true"),

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -110,33 +110,6 @@ class HomeActivity : UIObject, AppCompatActivity() {
         }
     }
 
-    @Suppress("DEPRECATION")
-    private fun hideNavigationBar() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.insetsController?.apply {
-                hide(WindowInsets.Type.navigationBars())
-                systemBarsBehavior =
-                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            }
-        } else {
-            val decorView = window.decorView
-            val uiOptions = (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                    or View.SYSTEM_UI_FLAG_IMMERSIVE
-                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
-
-            // Try to hide the navigation bar but do not hide the status bar
-            decorView.systemUiVisibility = uiOptions
-
-            // Add listener to hide the navigation bar
-            decorView.setOnSystemUiVisibilityChangeListener { visibility ->
-                if (visibility and View.SYSTEM_UI_FLAG_FULLSCREEN == 0) {
-                    decorView.systemUiVisibility = uiOptions
-                }
-            }
-        }
-    }
 
     private fun updateSettingsFallbackButtonVisibility() {
         // If µLauncher settings can not be reached from any action bound to an enabled gesture,

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -10,6 +10,8 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.Window
+import android.view.WindowInsets
+import android.view.WindowInsetsController
 import android.window.OnBackInvokedDispatcher
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
@@ -111,14 +113,18 @@ class HomeActivity : UIObject, AppCompatActivity() {
     @Suppress("DEPRECATION")
     private fun hideNavigationBar() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val windowInsetsController = window.insetsController ?: return
-            windowInsetsController.hide(android.view.WindowInsets.Type.navigationBars())
-            windowInsetsController.systemBarsBehavior =
-                android.view.WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            window.insetsController?.apply {
+                hide(WindowInsets.Type.navigationBars())
+                systemBarsBehavior =
+                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
         } else {
             val decorView = window.decorView
-            val uiOptions =
-                (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or View.SYSTEM_UI_FLAG_IMMERSIVE or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
+            val uiOptions = (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    or View.SYSTEM_UI_FLAG_IMMERSIVE
+                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
 
             // Try to hide the navigation bar but do not hide the status bar
             decorView.systemUiVisibility = uiOptions
@@ -219,6 +225,7 @@ class HomeActivity : UIObject, AppCompatActivity() {
                 // Only used pre Android 13, cf. onBackInvokedDispatcher
                 handleBack()
             }
+
             KeyEvent.KEYCODE_VOLUME_UP -> {
                 if (Action.forGesture(Gesture.VOLUME_UP) == LauncherAction.VOLUME_UP) {
                     // Let the OS handle the key event. This works better with some custom ROMs

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -9,6 +9,7 @@ import android.util.DisplayMetrics
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import android.view.Window
 import android.window.OnBackInvokedDispatcher
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
@@ -97,6 +98,38 @@ class HomeActivity : UIObject, AppCompatActivity() {
         LauncherPreferences.getSharedPreferences()
             .registerOnSharedPreferenceChangeListener(sharedPreferencesListener)
 
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+
+        if (hasFocus && LauncherPreferences.display().hideNavigationBar()) {
+            hideNavigationBar()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun hideNavigationBar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val windowInsetsController = window.insetsController ?: return
+            windowInsetsController.hide(android.view.WindowInsets.Type.navigationBars())
+            windowInsetsController.systemBarsBehavior =
+                android.view.WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        } else {
+            val decorView = window.decorView
+            val uiOptions =
+                (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or View.SYSTEM_UI_FLAG_IMMERSIVE or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
+
+            // Try to hide the navigation bar but do not hide the status bar
+            decorView.systemUiVisibility = uiOptions
+
+            // Add listener to hide the navigation bar
+            decorView.setOnSystemUiVisibilityChangeListener { visibility ->
+                if (visibility and View.SYSTEM_UI_FLAG_FULLSCREEN == 0) {
+                    decorView.systemUiVisibility = uiOptions
+                }
+            }
+        }
     }
 
     private fun updateSettingsFallbackButtonVisibility() {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/ListActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/ListActivity.kt
@@ -155,7 +155,7 @@ class ListActivity : AppCompatActivity(), UIObject {
                     binding.listContainer.context.resources.displayMetrics.heightPixels
                 val diff = height - r.bottom
                 if (diff != 0 &&
-                    LauncherPreferences.display().fullScreen()
+                    LauncherPreferences.display().hideStatusBar()
                 ) {
                     if (binding.listContainer.paddingBottom != diff) {
                         binding.listContainer.setPadding(0, 0, 0, diff)

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -135,8 +135,8 @@
           -
           -->
         <string name="settings_display_screen_timeout_disabled_key" translatable="false">display.disable_timeout</string>
-        <string name="settings_display_full_screen_key" translatable="false">display.use_full_screen</string>
         <string name="settings_display_rotate_screen_key" translatable="false">display.rotate_screen</string>
+        <string name="settings_display_hide_status_bar_key" translatable="false">display.use_full_screen</string>
         <string name="settings_display_hide_navigation_bar_key" translatable="false">display.hide_navigation</string>
 
         <string name="settings_enabled_gestures_double_swipe_key" translatable="false">enabled_gestures.double_actions</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -137,6 +137,7 @@
         <string name="settings_display_screen_timeout_disabled_key" translatable="false">display.disable_timeout</string>
         <string name="settings_display_full_screen_key" translatable="false">display.use_full_screen</string>
         <string name="settings_display_rotate_screen_key" translatable="false">display.rotate_screen</string>
+        <string name="settings_display_hide_navigation_bar_key" translatable="false">display.hide_navigation</string>
 
         <string name="settings_enabled_gestures_double_swipe_key" translatable="false">enabled_gestures.double_actions</string>
         <string name="settings_enabled_gestures_edge_swipe_key" translatable="false">enabled_gestures.edge_actions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,9 +153,9 @@
     <string name="settings_launcher_section_display">Display</string>
 
     <string name="settings_display_screen_timeout_disabled">Keep screen on</string>
-    <string name="settings_display_full_screen">Use full screen</string>
-    <string name="settings_display_rotate_screen">Rotate screen</string>
+    <string name="settings_display_hide_status_bar">Hide status bar</string>
     <string name="settings_display_hide_navigation_bar">Hide navigation bar</string>
+    <string name="settings_display_rotate_screen">Rotate screen</string>
 
     <string name="settings_launcher_section_functionality">Functionality</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,7 @@
     <string name="settings_display_screen_timeout_disabled">Keep screen on</string>
     <string name="settings_display_full_screen">Use full screen</string>
     <string name="settings_display_rotate_screen">Rotate screen</string>
+    <string name="settings_display_hide_navigation_bar">Hide navigation bar</string>
 
     <string name="settings_launcher_section_functionality">Functionality</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -180,6 +180,10 @@
             android:key="@string/settings_display_screen_timeout_disabled_key"
             android:defaultValue="false"
             android:title="@string/settings_display_screen_timeout_disabled"/>
+        <SwitchPreference
+            android:key="@string/settings_display_hide_navigation_bar_key"
+            android:defaultValue="false"
+            android:title="@string/settings_display_hide_navigation_bar"/>
 
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -169,10 +169,6 @@
         android:title="@string/settings_launcher_section_display"
         app:allowDividerAbove="false">
         <SwitchPreference
-            android:key="@string/settings_display_full_screen_key"
-            android:defaultValue="true"
-            android:title="@string/settings_display_full_screen"/>
-        <SwitchPreference
             android:key="@string/settings_display_rotate_screen_key"
             android:defaultValue="true"
             android:title="@string/settings_display_rotate_screen"/>
@@ -180,6 +176,10 @@
             android:key="@string/settings_display_screen_timeout_disabled_key"
             android:defaultValue="false"
             android:title="@string/settings_display_screen_timeout_disabled"/>
+        <SwitchPreference
+            android:key="@string/settings_display_hide_status_bar_key"
+            android:defaultValue="true"
+            android:title="@string/settings_display_hide_status_bar"/>
         <SwitchPreference
             android:key="@string/settings_display_hide_navigation_bar_key"
             android:defaultValue="false"


### PR DESCRIPTION
To make the launcher more minimal on older Android version, I'd like to add the ability for user to hide the navigation bar on home screen. Toggling the "Use full screen" option does not hide the navigation bar, so I looked for another way to do it. I have tested the changes on my phones running Android 8.1 and Android 14.
This is my first ever PR, so any guidance or comment is appreciated.