### PR TITLE
Improve widget list layout

### DIFF
--- a/app/src/main/res/layout/list_widgets_row.xml
+++ b/app/src/main/res/layout/list_widgets_row.xml
@@ -6,55 +6,94 @@
     android:id="@+id/list_apps_row_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="15sp">
+    android:layout_marginTop="15sp"
+    android:layout_marginHorizontal="30sp">
 
-
-    <ImageView
-        android:id="@+id/list_widgets_row_icon"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:src="@mipmap/ic_launcher_round"
-        tools:ignore="ContentDescription" />
-
-
-    <TextView
-        android:id="@+id/list_widgets_row_name"
-        android:layout_width="0dp"
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="10sp"
-        android:layout_marginEnd="10sp"
-        android:gravity="start"
-        android:text=""
-        android:textSize="20sp"
-        tools:text="some widget"
-        app:layout_constraintStart_toEndOf="@id/list_widgets_row_icon"
+        android:backgroundTint="#00000000"
+        app:cardElevation="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/list_widgets_row_description"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="10sp"
-        android:gravity="start"
-        android:text=""
-        android:textSize="12sp"
-        app:layout_constraintStart_toStartOf="@+id/list_widgets_row_name"
-        app:layout_constraintTop_toBottomOf="@+id/list_widgets_row_name"
-        tools:text="a longer description of the widget" />
-    <ImageView
-        android:id="@+id/list_widgets_row_preview"
-        android:layout_width="0dp"
-        android:maxHeight="100dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginEnd="0dp"
-        android:layout_height="100dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/list_widgets_row_description"
-        tools:src="@mipmap/ic_launcher_round"
-        tools:ignore="ContentDescription" />
+        app:layout_constraintTop_toTopOf="parent">
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/icon_title_description_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+
+                <ImageView
+                    android:id="@+id/list_widgets_row_icon"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    tools:src="@mipmap/ic_launcher_round"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:ignore="ContentDescription" />
+
+                <TextView
+                    android:id="@+id/list_widgets_row_name"
+                    android:layout_height="wrap_content"
+                    android:layout_width="wrap_content"
+                    android:layout_marginStart="10sp"
+                    android:layout_marginEnd="10sp"
+                    android:text=""
+                    style="@style/TextAppearance.Material3.HeadlineSmall"
+                    tools:text="Some Widget"
+                    app:layout_constraintStart_toEndOf="@id/list_widgets_row_icon"
+                    app:layout_constraintTop_toTopOf="@id/list_widgets_row_icon"
+                    app:layout_constraintBottom_toBottomOf="@id/list_widgets_row_icon"/>
+
+
+                <TextView
+                    android:id="@+id/list_widgets_row_description"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    android:textSize="12sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/list_widgets_row_name"
+                    app:layout_constraintTop_toBottomOf="@+id/list_widgets_row_name"
+                    tools:text="A longer description of the widget that may take up multiple lines." />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="10dp"
+                app:layout_constraintTop_toBottomOf="@id/icon_title_description_container">
+
+
+                <ImageView
+                    android:id="@+id/list_widgets_row_preview"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dp"
+                    android:maxHeight="100dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/list_widgets_row_icon"
+                    tools:src="@mipmap/ic_launcher_round"
+                    tools:ignore="ContentDescription,NotSibling" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.cardview.widget.CardView>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
For #178

## Summary of Key Changes:

- [x] :star: Containerize icon-title-description and widget preview to allow better separation and containment of elements and prevent overlap.
- [x] Vertically align `list_widgets_row_name` with `list_widgets_row_icon`.
- [x] Decrease the excess margin below each widget card by limiting the margin to the top and horizontal aspects.
- [x] Better content width matching to parent containers.
- [x] Replace `list_widgets_row_name` size of `20sp` with `@style/TextAppearance.Material3.HeadlineSmall`.

## Layout Preview
![Screenshot from 2025-05-19 16-38-02](https://github.com/user-attachments/assets/def845ad-53a6-45ff-9080-de1f9c6cf491)

## Sample Screenshots

### Android 16

![image](https://github.com/user-attachments/assets/9d1ef04d-8701-4b94-8e68-6aa93b291c4b)

### Android 12

![image](https://github.com/user-attachments/assets/4754341b-3919-485b-bf27-ae4af90385fb)
