### PR TITLE
fix wide buttons on larger screens

### DIFF
--- a/app/src/main/res/layout/activity_pin_shortcut.xml
+++ b/app/src/main/res/layout/activity_pin_shortcut.xml
@@ -63,62 +63,77 @@
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/pin_shortcut_appbar">
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_margin="20dp"
-            android:orientation="vertical">
+            android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/pin_shortcut_label"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_margin="50dp"
-                android:drawablePadding="10dp"
-                android:gravity="center_vertical"
-                android:minHeight="40dp"
-                tools:drawableLeft="@drawable/baseline_settings_24"
-                tools:text="Shortcut name" />
+                android:layout_gravity="center_vertical"
+                android:layout_margin="20dp"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="@dimen/max_button_width">
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="10dp" />
+                <TextView
+                    android:id="@+id/pin_shortcut_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_margin="50dp"
+                    android:drawablePadding="10dp"
+                    android:gravity="center_vertical"
+                    android:minHeight="40dp"
+                    tools:drawableLeft="@drawable/baseline_settings_24"
+                    tools:text="Shortcut name" />
 
-            <CheckBox
-                android:id="@+id/pin_shortcut_switch_visible"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textColor="?android:textColor"
-                android:checked="true"
-                android:text="@string/pin_shortcut_switch_visible" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="10dp" />
+                <CheckBox
+                    android:id="@+id/pin_shortcut_switch_visible"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp"
+                    android:textColor="?android:textColor"
+                    android:checked="true"
+                    android:text="@string/pin_shortcut_switch_visible" />
 
-            <Button
-                android:id="@+id/pin_shortcut_button_bind"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/pin_shortcut_button_bind" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="10dp" />
+                <Button
+                    android:id="@+id/pin_shortcut_button_bind"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp"
+                    android:text="@string/pin_shortcut_button_bind" />
 
-        </LinearLayout>
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>
 
     <Button
         android:id="@+id/pin_shortcut_button_ok"
         android:layout_margin="10dp"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:text="@android:string/ok"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="@dimen/max_button_width" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_pin_shortcut.xml
+++ b/app/src/main/res/layout/activity_pin_shortcut.xml
@@ -28,7 +28,7 @@
 
             <TextView
                 android:id="@+id/list_heading"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:gravity="center"
                 android:minHeight="?actionBarSize"

--- a/app/src/main/res/layout/activity_report_crash.xml
+++ b/app/src/main/res/layout/activity_report_crash.xml
@@ -25,38 +25,52 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
+            xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="10dp">
+            android:layout_height="wrap_content">
 
-            <de.jrpie.android.launcher.ui.util.HtmlTextView
-                android:layout_width="match_parent"
+            <LinearLayout
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/crash_info" />
+                android:orientation="vertical"
+                android:padding="10dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="@dimen/max_button_width">
 
-            <Button
-                android:id="@+id/report_crash_button_copy"
-                android:text="@string/report_crash_button_copy"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                <de.jrpie.android.launcher.ui.util.HtmlTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/crash_info" />
 
-            <Space
-                android:layout_width="match_parent"
-                android:layout_height="20dp" />
+                <Button
+                    android:id="@+id/report_crash_button_copy"
+                    android:text="@string/report_crash_button_copy"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
 
-            <Button
-                android:id="@+id/report_crash_button_mail"
-                android:text="@string/report_crash_button_mail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="20dp" />
 
-            <Button
-                android:id="@+id/report_crash_button_report"
-                android:text="@string/report_crash_button_report"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
+                <Button
+                    android:id="@+id/report_crash_button_mail"
+                    android:text="@string/report_crash_button_mail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+
+                <Button
+                    android:id="@+id/report_crash_button_report"
+                    android:text="@string/report_crash_button_report"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp" />
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_select_widget.xml
+++ b/app/src/main/res/layout/activity_select_widget.xml
@@ -60,7 +60,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/select_widget_recycler"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"

--- a/app/src/main/res/layout/dialog_choose_color.xml
+++ b/app/src/main/res/layout/dialog_choose_color.xml
@@ -33,6 +33,7 @@
         android:id="@+id/dialog_select_color_seekbar_alpha"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:max="255" />
 
     <Space
@@ -48,6 +49,7 @@
         android:id="@+id/dialog_select_color_seekbar_red"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:max="255" />
 
     <Space
@@ -63,6 +65,7 @@
         android:id="@+id/dialog_select_color_seekbar_green"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:max="255" />
 
     <Space
@@ -78,6 +81,7 @@
         android:id="@+id/dialog_select_color_seekbar_blue"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:max="255" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/list_apps.xml
+++ b/app/src/main/res/layout/list_apps.xml
@@ -32,33 +32,43 @@
 
     </androidx.recyclerview.widget.RecyclerView>
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_margin="8dp">
 
-        <androidx.appcompat.widget.SearchView
-            android:id="@+id/list_apps_searchview"
-            android:layout_width="fill_parent"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:iconifiedByDefault="false"
-            app:iconifiedByDefault="false"
-            app:queryHint="@string/list_apps_search_hint"
-            app:searchHintIcon="@drawable/baseline_search_24"
-            app:searchIcon="@drawable/baseline_search_24" />
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_max="@dimen/max_search_bar_width">
 
-        <CheckBox
-            android:id="@+id/list_apps_check_box_favorites"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_weight="0"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@string/content_description_toggle_favorites"
-            android:button="@drawable/checkbox_favorite" />
+            <androidx.appcompat.widget.SearchView
+                android:id="@+id/list_apps_searchview"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:iconifiedByDefault="false"
+                app:iconifiedByDefault="false"
+                app:queryHint="@string/list_apps_search_hint"
+                app:searchHintIcon="@drawable/baseline_search_24"
+                app:searchIcon="@drawable/baseline_search_24" />
 
-    </LinearLayout>
+            <CheckBox
+                android:id="@+id/list_apps_check_box_favorites"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:layout_marginEnd="16dp"
+                android:contentDescription="@string/content_description_toggle_favorites"
+                android:button="@drawable/checkbox_favorite" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 
 </LinearLayout>

--- a/app/src/main/res/layout/settings_actions.xml
+++ b/app/src/main/res/layout/settings_actions.xml
@@ -23,18 +23,20 @@
 
     <LinearLayout
         android:id="@+id/settings_actions_buttons"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="32dp"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="@dimen/max_button_width">
 
         <Button
             android:id="@+id/settings_actions_button_install_apps"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="48dp"
             android:text="@string/settings_apps_install"
             android:textAllCaps="false" />
 

--- a/app/src/main/res/layout/settings_actions.xml
+++ b/app/src/main/res/layout/settings_actions.xml
@@ -13,7 +13,7 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/settings_actions_rview_fragment"
         android:name="de.jrpie.android.launcher.ui.settings.actions.SettingsFragmentActionsRecycler"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toTopOf="@+id/settings_actions_buttons"

--- a/app/src/main/res/layout/settings_meta.xml
+++ b/app/src/main/res/layout/settings_meta.xml
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/settings_meta_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     tools:context=".ui.settings.meta.SettingsFragmentMeta">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center|top"
         android:orientation="vertical"
         android:paddingLeft="32sp"
         android:paddingTop="16sp"
-        android:paddingRight="32sp">
+        android:paddingRight="32sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="@dimen/max_button_width">
 
 
         <Button
@@ -117,4 +126,6 @@
             tools:text="v1.2.3" />
 
     </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/tutorial_2_usage.xml
+++ b/app/src/main/res/layout/tutorial_2_usage.xml
@@ -42,7 +42,7 @@
         android:src="@drawable/tutorial_home_screen"
         app:layout_constraintBottom_toTopOf="@id/tutorial_usage_text_2"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/tutorial_usage_text"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tutorial_usage_text"
         app:srcCompat="@drawable/tutorial_home_screen"
         tools:ignore="ContentDescription" />

--- a/app/src/main/res/layout/tutorial_3_app_list.xml
+++ b/app/src/main/res/layout/tutorial_3_app_list.xml
@@ -42,7 +42,7 @@
         android:src="@drawable/tutorial_app_list"
         app:layout_constraintBottom_toTopOf="@id/tutorial_app_list_text_2"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/tutorial_app_list_text"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tutorial_app_list_text"
         app:srcCompat="@drawable/tutorial_app_list"
         tools:ignore="ContentDescription" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,6 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="appbar_padding">16dp</dimen>
     <dimen name="app_icon_side">40dip</dimen>
+    <dimen name="max_button_width">400dp</dimen>
+    <dimen name="max_search_bar_width">600dp</dimen>
 </resources>


### PR DESCRIPTION
for #83

In general, this limits buttons to 320dp, per Material Design "best practice"(?), but this "best practice" may be changing according to this issue thread [here](https://github.com/material-components/material-components-android/issues/4102).

Also increases touch target size to a more accessible 48dp. 

Without things crashing, I couldn't find a clean way to get the app drawer list off the left edge of the screen (on larger screens). This likely has to do with how the ImageView and TextViews for the apps are expected somewhere upstream when the drawer is launched, but I don't have the time or brainpower to trace that one out yet.