### PR TITLE
Add setting for app name capitalization

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import de.jrpie.android.launcher.R;
 import de.jrpie.android.launcher.actions.lock.LockMethod;
+import de.jrpie.android.launcher.preferences.list.AppName;
+import de.jrpie.android.launcher.preferences.list.ListLayout;
 import de.jrpie.android.launcher.preferences.serialization.MapAbstractAppInfoStringPreferenceSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetAbstractAppInfoPreferenceSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetPinnedShortcutInfoPreferenceSerializer;
@@ -40,7 +42,8 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 }),
                 @PreferenceGroup(name = "list", prefix = "settings_list_", suffix = "_key", value = {
                         @Preference(name = "layout", type = ListLayout.class, defaultValue = "DEFAULT"),
-                        @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false")
+                        @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false"),
+                        @Preference(name= "app_names", type = AppName.class, defaultValue = "DEFAULT")
                 }),
                 @PreferenceGroup(name = "gestures", prefix = "settings_gesture_", suffix = "_key", value = {
                 }),

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 import de.jrpie.android.launcher.R;
 import de.jrpie.android.launcher.actions.lock.LockMethod;
-import de.jrpie.android.launcher.preferences.list.AppName;
+import de.jrpie.android.launcher.preferences.list.AppNameFormat;
 import de.jrpie.android.launcher.preferences.list.ListLayout;
 import de.jrpie.android.launcher.preferences.serialization.MapAbstractAppInfoStringPreferenceSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetAbstractAppInfoPreferenceSerializer;
@@ -43,7 +43,7 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 @PreferenceGroup(name = "list", prefix = "settings_list_", suffix = "_key", value = {
                         @Preference(name = "layout", type = ListLayout.class, defaultValue = "DEFAULT"),
                         @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false"),
-                        @Preference(name= "app_names", type = AppName.class, defaultValue = "DEFAULT")
+                        @Preference(name= "app_name_format", type = AppNameFormat.class, defaultValue = "DEFAULT")
                 }),
                 @PreferenceGroup(name = "gestures", prefix = "settings_gesture_", suffix = "_key", value = {
                 }),

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppName.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppName.kt
@@ -1,7 +1,0 @@
-package de.jrpie.android.launcher.preferences.list
-
-enum class AppName {
-    DEFAULT,
-    UPPERCASE,
-    LOWERCASE,
-}

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppName.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppName.kt
@@ -1,0 +1,7 @@
+package de.jrpie.android.launcher.preferences.list
+
+enum class AppName {
+    DEFAULT,
+    UPPERCASE,
+    LOWERCASE,
+}

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppNameFormat.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppNameFormat.kt
@@ -1,0 +1,22 @@
+package de.jrpie.android.launcher.preferences.list
+
+@Suppress("unused")
+enum class AppNameFormat {
+    DEFAULT {
+        override fun format(input: String): String {
+            return input
+        }
+    },
+    UPPERCASE {
+        override fun format(input: String): String {
+            return input.uppercase()
+        }
+    },
+    LOWERCASE {
+        override fun format(input: String): String {
+            return input.lowercase()
+        }
+    };
+
+    abstract fun format(input: String): String
+}

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/list/ListLayout.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/list/ListLayout.kt
@@ -1,4 +1,4 @@
-package de.jrpie.android.launcher.preferences
+package de.jrpie.android.launcher.preferences.list
 
 import android.content.Context
 import android.util.TypedValue
@@ -6,7 +6,6 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.jrpie.android.launcher.R
-
 
 // TODO: move this to de.jrpie.android.launcher.ui.list.apps ?
 @Suppress("unused")

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
@@ -21,7 +21,8 @@ import de.jrpie.android.launcher.apps.AppFilter
 import de.jrpie.android.launcher.apps.AppInfo
 import de.jrpie.android.launcher.apps.DetailedAppInfo
 import de.jrpie.android.launcher.preferences.LauncherPreferences
-import de.jrpie.android.launcher.preferences.ListLayout
+import de.jrpie.android.launcher.preferences.list.AppName
+import de.jrpie.android.launcher.preferences.list.ListLayout
 import de.jrpie.android.launcher.ui.list.ListActivity
 import de.jrpie.android.launcher.ui.transformGrayscale
 
@@ -91,7 +92,11 @@ class AppsRecyclerAdapter(
                 appsListDisplayed[i].getUser(activity)
             ).toString()
         }
-        viewHolder.textView.text = appLabel
+        viewHolder.textView.text = when (LauncherPreferences.list().appNames()) {
+            AppName.DEFAULT -> appLabel
+            AppName.UPPERCASE -> appLabel.uppercase()
+            AppName.LOWERCASE -> appLabel.lowercase()
+        }
 
 
         // decide when to show the options popup menu about

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
@@ -21,7 +21,7 @@ import de.jrpie.android.launcher.apps.AppFilter
 import de.jrpie.android.launcher.apps.AppInfo
 import de.jrpie.android.launcher.apps.DetailedAppInfo
 import de.jrpie.android.launcher.preferences.LauncherPreferences
-import de.jrpie.android.launcher.preferences.list.AppName
+import de.jrpie.android.launcher.preferences.list.AppNameFormat
 import de.jrpie.android.launcher.preferences.list.ListLayout
 import de.jrpie.android.launcher.ui.list.ListActivity
 import de.jrpie.android.launcher.ui.transformGrayscale
@@ -42,7 +42,8 @@ class AppsRecyclerAdapter(
     = ListActivity.ListActivityIntention.VIEW,
     private val forGesture: String? = "",
     private var appFilter: AppFilter = AppFilter(activity, ""),
-    private val layout: ListLayout
+    private val layout: ListLayout,
+    private val nameFormat: AppNameFormat
 ) :
     RecyclerView.Adapter<AppsRecyclerAdapter.ViewHolder>() {
 
@@ -92,11 +93,7 @@ class AppsRecyclerAdapter(
                 appsListDisplayed[i].getUser(activity)
             ).toString()
         }
-        viewHolder.textView.text = when (LauncherPreferences.list().appNames()) {
-            AppName.DEFAULT -> appLabel
-            AppName.UPPERCASE -> appLabel.uppercase()
-            AppName.LOWERCASE -> appLabel.lowercase()
-        }
+        viewHolder.textView.text = nameFormat.format(appLabel)
 
 
         // decide when to show the options popup menu about

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -26,7 +26,7 @@ import kotlin.math.absoluteValue
 /**
  * The [ListFragmentApps] is used as a tab in ListActivity.
  *
- * It is a list of all installed applications that are can be launched.
+ * It is a list of all installed applications that can be launched.
  */
 class ListFragmentApps : Fragment(), UIObject {
     private lateinit var binding: ListAppsBinding
@@ -77,7 +77,8 @@ class ListFragmentApps : Fragment(), UIObject {
                     privateSpaceVisibility = listActivity.privateSpaceVisibility,
                     hiddenVisibility = listActivity.hiddenVisibility
                 ),
-                layout = LauncherPreferences.list().layout()
+                layout = LauncherPreferences.list().layout(),
+                nameFormat = LauncherPreferences.list().appNameFormat()
             )
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,9 +105,9 @@
     <string name="settings_functionality_search_web_summary">Beim Durchsuchen der Apps Enter drücken, um stattdessen im Internet zu suchen.</string>
     <string name="settings_functionality_auto_keyboard">Tastatur automatisch öffnen</string>
     <string name="settings_launcher_sensitivity">Empfindlichkeit</string>
-    <string name="settings_list_app_names_item_default">Normal</string>
-    <string name="settings_list_app_names_item_uppercase">Grossbuchstaben</string>
-    <string name="settings_list_app_names_item_lowercase">Kleinbuchstaben</string>
+    <string name="settings_list_app_name_format_item_default">Normal</string>
+    <string name="settings_list_app_name_format_item_uppercase">Grossbuchstaben</string>
+    <string name="settings_list_app_name_format_item_lowercase">Kleinbuchstaben</string>
     <!--
       -
       - Settings : Meta

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,6 +105,9 @@
     <string name="settings_functionality_search_web_summary">Beim Durchsuchen der Apps Enter drücken, um stattdessen im Internet zu suchen.</string>
     <string name="settings_functionality_auto_keyboard">Tastatur automatisch öffnen</string>
     <string name="settings_launcher_sensitivity">Empfindlichkeit</string>
+    <string name="settings_list_app_names_item_default">Normal</string>
+    <string name="settings_list_app_names_item_uppercase">Grossbuchstaben</string>
+    <string name="settings_list_app_names_item_lowercase">Kleinbuchstaben</string>
     <!--
       -
       - Settings : Meta

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -19,10 +19,11 @@
         <string name="settings_apps_hide_paused_apps_key" translatable="false">apps.hide_paused_apps</string>
         <string name="settings_apps_hide_private_space_apps_key" translatable="false">apps.hide_private_space_apps</string>
         <string name="settings_list_layout_key" translatable="false">list.layout</string>
+        <string name="settings_list_app_names_key" translatable="false">list.app_names</string>
         <string name="settings_list_reverse_layout_key" translatable="false">list.reverse_layout</string>
         <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
 
-        <!-- values of de.jrpie.android.launcher.preferences.ListLayout -->
+        <!-- values of de.jrpie.android.launcher.preferences.list.ListLayout -->
         <string-array name="settings_list_layout_values" translatable="false">
                 <item>DEFAULT</item>
                 <item>TEXT</item>
@@ -34,6 +35,20 @@
                 <item>@string/settings_list_layout_item_text</item>
                 <item>@string/settings_list_layout_item_grid</item>
         </string-array>
+
+        <!-- values de.jrpie.android.launcher.preferences.list.AppName -->
+        <string-array name="settings_list_app_names_values" translatable="false">
+            <item>DEFAULT</item>
+            <item>UPPERCASE</item>
+            <item>LOWERCASE</item>
+        </string-array>
+
+        <string-array name="settings_list_app_names_items" translatable="false">
+            <item>@string/settings_list_app_names_item_default</item>
+            <item>@string/settings_list_app_names_item_uppercase</item>
+            <item>@string/settings_list_app_names_item_lowercase</item>
+        </string-array>
+
         <!--
           -
           - Settings : Gestures

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -19,7 +19,7 @@
         <string name="settings_apps_hide_paused_apps_key" translatable="false">apps.hide_paused_apps</string>
         <string name="settings_apps_hide_private_space_apps_key" translatable="false">apps.hide_private_space_apps</string>
         <string name="settings_list_layout_key" translatable="false">list.layout</string>
-        <string name="settings_list_app_names_key" translatable="false">list.app_names</string>
+        <string name="settings_list_app_name_format_key" translatable="false">list.app_name_format</string>
         <string name="settings_list_reverse_layout_key" translatable="false">list.reverse_layout</string>
         <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
 
@@ -37,16 +37,16 @@
         </string-array>
 
         <!-- values de.jrpie.android.launcher.preferences.list.AppName -->
-        <string-array name="settings_list_app_names_values" translatable="false">
+        <string-array name="settings_list_app_name_format_values" translatable="false">
             <item>DEFAULT</item>
             <item>UPPERCASE</item>
             <item>LOWERCASE</item>
         </string-array>
 
-        <string-array name="settings_list_app_names_items" translatable="false">
-            <item>@string/settings_list_app_names_item_default</item>
-            <item>@string/settings_list_app_names_item_uppercase</item>
-            <item>@string/settings_list_app_names_item_lowercase</item>
+        <string-array name="settings_list_app_name_format_items" translatable="false">
+            <item>@string/settings_list_app_name_format_item_default</item>
+            <item>@string/settings_list_app_name_format_item_uppercase</item>
+            <item>@string/settings_list_app_name_format_item_lowercase</item>
         </string-array>
 
         <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,10 +181,15 @@
     <string name="settings_apps_hide_private_space_apps">Hide private space from app list</string>
     <string name="settings_list_layout">Layout of app list</string>
     <string name="settings_list_reverse_layout">Reverse the app list</string>
+    <string name="settings_list_app_names">Names of Apps</string>
 
     <string name="settings_list_layout_item_default">Default</string>
     <string name="settings_list_layout_item_text">Text</string>
     <string name="settings_list_layout_item_grid">Grid</string>
+
+    <string name="settings_list_app_names_item_default">Default</string>
+    <string name="settings_list_app_names_item_uppercase">Uppercase</string>
+    <string name="settings_list_app_names_item_lowercase">Lowercase</string>
 
     <!--
       -

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,15 +181,15 @@
     <string name="settings_apps_hide_private_space_apps">Hide private space from app list</string>
     <string name="settings_list_layout">Layout of app list</string>
     <string name="settings_list_reverse_layout">Reverse the app list</string>
-    <string name="settings_list_app_names">Names of Apps</string>
+    <string name="settings_list_app_name_format">Names of Apps</string>
 
     <string name="settings_list_layout_item_default">Default</string>
     <string name="settings_list_layout_item_text">Text</string>
     <string name="settings_list_layout_item_grid">Grid</string>
 
-    <string name="settings_list_app_names_item_default">Default</string>
-    <string name="settings_list_app_names_item_uppercase">Uppercase</string>
-    <string name="settings_list_app_names_item_lowercase">Lowercase</string>
+    <string name="settings_list_app_name_format_item_default">Default</string>
+    <string name="settings_list_app_name_format_item_uppercase">Uppercase</string>
+    <string name="settings_list_app_name_format_item_lowercase">Lowercase</string>
 
     <!--
       -

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -167,6 +167,13 @@
             android:entryValues="@array/settings_list_layout_values"
             android:summary="%s"
             android:defaultValue="DEFAULT"/>
+        <DropDownPreference
+            android:key="list.app_names"
+            android:title="Names of Apps"
+            android:entries="@array/settings_list_app_names_items"
+            android:entryValues="@array/settings_list_app_names_values"
+            android:summary="%s"
+            android:defaultValue="DEFAULT"/>
 
         <SwitchPreference
             android:key="@string/settings_list_reverse_layout_key"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -168,10 +168,10 @@
             android:summary="%s"
             android:defaultValue="DEFAULT"/>
         <DropDownPreference
-            android:key="list.app_names"
+            android:key="list.app_name_format"
             android:title="Names of Apps"
-            android:entries="@array/settings_list_app_names_items"
-            android:entryValues="@array/settings_list_app_names_values"
+            android:entries="@array/settings_list_app_name_format_items"
+            android:entryValues="@array/settings_list_app_name_format_values"
             android:summary="%s"
             android:defaultValue="DEFAULT"/>
 


### PR DESCRIPTION
I added the name capitalization setting I asked in the chat about.

This also refactors the layout setting enum so the two list settings are in the same place, though there was a todo in the code about something similar, so I am unsure if this is the way you prefer.

Thank you for your work on the launcher 🙏
