### PR TITLE
in settings: Changed gesture display order

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
@@ -267,9 +267,9 @@ enum class Gesture(
 
     fun getDoubleVariant(): Gesture {
         return when (this) {
-            SWIPE_UP    -> SWIPE_UP_DOUBLE
-            SWIPE_DOWN  -> SWIPE_DOWN_DOUBLE
-            SWIPE_LEFT  -> SWIPE_LEFT_DOUBLE
+            SWIPE_UP -> SWIPE_UP_DOUBLE
+            SWIPE_DOWN -> SWIPE_DOWN_DOUBLE
+            SWIPE_LEFT -> SWIPE_LEFT_DOUBLE
             SWIPE_RIGHT -> SWIPE_RIGHT_DOUBLE
             else -> this
         }

--- a/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
@@ -46,6 +46,12 @@ enum class Gesture(
         R.string.settings_gesture_description_date,
         R.array.default_date
     ),
+    BACK(
+        "action.back",
+        R.string.settings_gesture_back,
+        R.string.settings_gesture_description_back,
+        R.array.default_back
+    ),
     LONG_CLICK(
         "action.long_click",
         R.string.settings_gesture_long_click,
@@ -245,12 +251,6 @@ enum class Gesture(
         R.string.settings_gesture_swipe_v_reverse,
         R.string.settings_gesture_description_swipe_v_reverse,
         R.array.no_default
-    ),
-    BACK(
-        "action.back",
-        R.string.settings_gesture_back,
-        R.string.settings_gesture_description_back,
-        R.array.default_back
     );
 
     enum class Edge {
@@ -267,9 +267,9 @@ enum class Gesture(
 
     fun getDoubleVariant(): Gesture {
         return when (this) {
-            SWIPE_UP -> SWIPE_UP_DOUBLE
-            SWIPE_DOWN -> SWIPE_DOWN_DOUBLE
-            SWIPE_LEFT -> SWIPE_LEFT_DOUBLE
+            SWIPE_UP    -> SWIPE_UP_DOUBLE
+            SWIPE_DOWN  -> SWIPE_DOWN_DOUBLE
+            SWIPE_LEFT  -> SWIPE_LEFT_DOUBLE
             SWIPE_RIGHT -> SWIPE_RIGHT_DOUBLE
             else -> this
         }


### PR DESCRIPTION
Move 'Tap on back' from the very end to be after the 'Tap on date' entry.