### PR TITLE
Fixed gesture navigation #126 & #229

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/ui/TouchGestureDetector.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/TouchGestureDetector.kt
@@ -37,8 +37,8 @@ class TouchGestureDetector(
 
     private var systemGestureInsetTop = 100
     private var systemGestureInsetBottom = 0
-    private var systemGestureInsetLeft = 0
-    private var systemGestureInsetRight = 0
+    private var systemGestureInsetLeft = 100
+    private var systemGestureInsetRight = 100
 
     private val longPressHandler = Handler(Looper.getMainLooper())
 


### PR DESCRIPTION
Summary

This PR fixes a bug where the launcher incorrectly detected the back gesture as a long_click.

Changes
- Adjusted systemGestureInsetLeft and systemGestureInsetRight values from 0 to 100.
- Corrected gesture handling logic so the back gesture is no longer misinterpreted as a long click.
- 
Result
- Back gesture works as expected.
- No unintended long click actions triggered by system gestures.