### PR TITLE
Added Hidden Apps to Actions Menu

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/actions/LauncherAction.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/actions/LauncherAction.kt
@@ -80,6 +80,13 @@ enum class LauncherAction(
             isPrivateSpaceSupported()
         }
     ),
+    CHOOSE_FROM_HIDDEN(
+        "choose_from_hidden",
+        R.string.list_other_list_hidden,
+        R.drawable.baseline_apps_24,
+        { context -> openAppsList(context, hidden = true) },
+        true
+    ),
     TOGGLE_PRIVATE_SPACE_LOCK(
         "toggle_private_space_lock",
         R.string.list_other_toggle_private_space_lock,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -142,6 +142,7 @@
     <string name="list_apps_search_hint_no_auto_launch">بحث (بدون تشغيل تلقائي)</string>
     <string name="list_other_settings">اعدادات التطبيق</string>
     <string name="list_other_list">درج التطبيقات</string>
+    <string name="list_other_list_hidden">التطبيقات المخفية</string>
     <string name="list_other_list_private_space">المساحة الخاصة</string>
     <string name="list_other_toggle_private_space_lock">تبديل قفل المساحة الخاصة</string>
     <string name="list_other_volume_up">ارفع الصوت</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -164,6 +164,7 @@
     <string name="list_title_favorite">Oblíbené aplikace</string>
     <string name="list_title_hidden">Skryté aplikace</string>
     <string name="list_title_private_space">Privátní prostor</string>
+    <string name="list_other_list_hidden">Skryté aplikace</string>
     <string name="list_other_list_private_space">Privární prostor</string>
     <string name="list_other_toggle_private_space_lock">Přepnout zámek privátního prostoru</string>
     <string name="toast_private_space_locked">Privátní prostor zamčen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -309,6 +309,7 @@
     <string name="settings_gesture_tap_right">Tippen und rechts</string>
     <string name="settings_gesture_description_tap_right">Tippen, dann nach rechts wischen</string>
     <string name="dialog_report_bug_security_info">Sicherheitslücken bitte nicht öffentlich bei GitHub melden, sondern auf dem folgenden Weg:</string>
+    <string name="list_other_list_hidden">Versteckte Apps</string>
     <string name="list_other_list_private_space">Privater Bereich</string>
     <string name="list_other_track_play_pause">Musik: Wiedergabe / Pause</string>
     <string name="settings_list_reverse_layout">Appliste umkehren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -252,6 +252,7 @@
     <string name="list_app_hidden_add">Esconder</string>
     <string name="list_app_rename">Renombrar</string>
     <string name="list_other_list_favorites">Aplicaciones favoritas</string>
+    <string name="list_other_list_hidden">Aplicaciones ocultas</string>
     <string name="list_other_list_private_space">Espacio privado</string>
     <string name="tutorial_app_list_text">Puede buscar rápidamente entre todas las aplicaciones en la lista de aplicaciones.\n\nDesliza hacia arriba para abrirlo o asigne un gesto diferente.</string>
     <string name="tutorial_app_list_text_2">Una vez que sólo coincide una aplicación, se inicia automáticamente.\nEsto se puede desactivar anteponiendo un espacio a la consulta.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -222,4 +222,5 @@
     <string name="settings_gesture_description_down_left_edge">Balayer vers le bas au bord gauche de l\'écran</string>
     <string name="settings_enabled_gestures_edge_swipe_summary">Balayer au bord de l\'écran</string>
     <string name="settings_clock_color">Couleur</string>
+    <string name="list_other_list_hidden">Applications masquées</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -238,6 +238,7 @@
     </ul>
      μLauncher <strong>non raccoglierà mai alcun dato</strong>. In particolare, μLauncher non utilizza il servizio di accessibilità per raccogliere dati.]]></string>
     <string name="list_title_private_space">Spazio privato</string>
+    <string name="list_other_list_hidden">Applicazioni nascoste</string>
     <string name="list_other_list_private_space">Spazio privato</string>
     <string name="list_other_volume_adjust">Regola volume</string>
     <string name="pin_shortcut_button_bind">Associa al gesto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -185,6 +185,7 @@
     <string name="settings_theme_background">背景（アプリ一覧と設定）</string>
     <string name="settings_enabled_gestures_edge_swipe_edge_width">端の幅</string>
     <string name="settings_functionality_auto_launch_summary">この機能を一時的に無効にするにはスペースキーを押します。</string>
+    <string name="list_other_list_hidden">非表示のアプリ</string>
     <string name="list_other_list_private_space">プライベートスペース</string>
     <string name="settings_apps_hide_private_space_apps">アプリ一覧からプライベートスペースを隠す</string>
     <string name="settings_meta_report_bug">バグを報告</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -116,6 +116,7 @@
     <string name="list_other_settings">µLauncher instellingen</string>
     <string name="list_other_list">Alle apps</string>
     <string name="list_other_list_favorites">Favoriete apps</string>
+    <string name="list_other_list_hidden">Verstopte apps</string>
     <string name="list_other_list_private_space">Privéruimte</string>
     <string name="list_other_toggle_private_space_lock">Privéruimte (ont)sluiten</string>
     <string name="list_other_volume_up">Volume omhoog</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -170,6 +170,7 @@
     <string name="list_apps_search_hint_no_auto_launch">Wyszukaj (brak automatycznego uruchomienia)</string>
     <string name="list_other_settings">Ustawienia μLauncher</string>
     <string name="list_other_list_favorites">Ulubione aplikacje</string>
+    <string name="list_other_list_hidden">Ukryte aplikacje</string>
     <string name="list_other_list_private_space">Przestrzeń prywatna</string>
     <string name="list_other_toggle_private_space_lock">Przełącz zamek prywatnej przestrzeni</string>
     <string name="list_other_volume_up">Podgłośnij</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -274,6 +274,7 @@
     <string name="settings_gesture_description_back">Botão Voltar / gesto de Voltar</string>
     <string name="settings_apps_hide_private_space_apps">Ocultar espaço privado na lista de apps</string>
     <string name="list_title_private_space">Espaço privado</string>
+    <string name="list_other_list_hidden">Apps ocultos</string>
     <string name="list_other_list_private_space">Espaço privado</string>
     <string name="tooltip_lock_private_space">Trancar espaço privado</string>
     <string name="tooltip_unlock_private_space">Liberar espaço privado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -77,6 +77,7 @@
     <string name="list_apps_search_hint_no_auto_launch">Поиск (без автозапуска)</string>
     <string name="list_other_settings">Настройки μLauncher</string>
     <string name="list_other_list">Все приложения</string>
+    <string name="list_other_list_hidden">Скрытое</string>
     <string name="list_other_list_private_space">Личное пространство</string>
     <string name="list_other_recent_apps">Недавние приложения</string>
     <string name="list_other_lock_screen">Заблокировать экран</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -200,4 +200,5 @@
     <string name="dialog_select_color_green">Yeşil</string>
     <string name="dialog_select_color_color_hex">Renk</string>
     <string name="dialog_choose_color_title">Renk seçin</string>
+    <string name="list_other_list_hidden">Gizli Uygulamalar</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -174,6 +174,7 @@
     <string name="dialog_select_color_green">绿色</string>
     <string name="settings_theme_color_theme_item_dynamic">动态</string>
     <string name="list_title_private_space">私人空间</string>
+    <string name="list_other_list_hidden">隐藏的应用</string>
     <string name="list_other_list_private_space">私人空间</string>
     <string name="dialog_choose_color_title">设置颜色</string>
     <string name="dialog_select_color_color_hex">颜色</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="list_other_settings">μLauncher Settings</string>
     <string name="list_other_list">All Applications</string>
     <string name="list_other_list_favorites">Favorite Applications</string>
+    <string name="list_other_list_hidden">Hidden Applications</string>
     <string name="list_other_list_private_space">Private Space</string>
     <string name="list_other_toggle_private_space_lock">Toggle Private Space Lock</string>
     <string name="list_other_volume_up">Raise Volume</string>


### PR DESCRIPTION
With those changes, users are now able to access the hidden apps list without opening the settings menu, by attaching the added action to a gesture

<img width="385" height="550" alt="image" src="https://github.com/user-attachments/assets/31a213c8-007e-4bf8-b17f-a24341ed9925" />