### PR TITLE
Add options for setting format strings of date and time

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -66,6 +66,8 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "flip_date_time", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "localized", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "show_seconds", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "date_format", type = String.class, defaultValue = "yyyy-MM-dd"),
+                        @Preference(name = "time_format", type = String.class, defaultValue = "h:mm:ss"),
                 }),
                 @PreferenceGroup(name = "display", prefix = "settings_display_", suffix = "_key", value = {
                         @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),

--- a/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
@@ -31,11 +31,17 @@ class SettingsFragmentLauncher : PreferenceFragmentCompat() {
         }
 
     private fun updateVisibility() {
-        val showSeconds = findPreference<androidx.preference.Preference>(
-            LauncherPreferences.clock().keys().showSeconds()
+        val timeFormat = findPreference<androidx.preference.Preference>(
+            LauncherPreferences.clock().keys().timeFormat()
         )
         val timeVisible = LauncherPreferences.clock().timeVisible()
-        showSeconds?.isVisible = timeVisible
+        timeFormat?.isVisible = timeVisible
+
+        val dateFormat = findPreference<androidx.preference.Preference>(
+            LauncherPreferences.clock().keys().dateFormat()
+        )
+        val dateVisible = LauncherPreferences.clock().dateVisible()
+        dateFormat?.isVisible = dateVisible
 
         val background = findPreference<androidx.preference.Preference>(
             LauncherPreferences.theme().keys().background()

--- a/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
@@ -38,11 +38,8 @@ class ClockView(
         val dateVisible = LauncherPreferences.clock().dateVisible()
         val timeVisible = LauncherPreferences.clock().timeVisible()
 
-        var dateFMT = "yyyy-MM-dd"
-        var timeFMT = "HH:mm"
-        if (LauncherPreferences.clock().showSeconds()) {
-            timeFMT += ":ss"
-        }
+        var dateFMT = LauncherPreferences.clock().dateFormat()
+        var timeFMT = LauncherPreferences.clock().timeFormat()
 
         if (LauncherPreferences.clock().localized()) {
             dateFMT = android.text.format.DateFormat.getBestDateTimePattern(locale, dateFMT)

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -149,6 +149,8 @@
     <string name="settings_clock_date_visible_key" translatable="false">clock.date_visible</string>
     <string name="settings_clock_localized_key" translatable="false">clock.date_localized</string>
     <string name="settings_clock_flip_date_time_key" translatable="false">clock.date_time_flip</string>
+    <string name="settings_clock_date_format_key" translatable="false">clock.date_format</string>
+    <string name="settings_clock_time_format_key" translatable="false">clock.time_format</string>
 
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,8 @@
     <string name="settings_clock_localized">Use localized date format</string>
     <string name="settings_clock_show_seconds">Show seconds</string>
     <string name="settings_clock_flip_date_time">Flip date and time</string>
+    <string name="settings_clock_date_format">Date format string</string>
+    <string name="settings_clock_time_format">Time format string</string>
 
     <string name="settings_theme_wallpaper">Choose a wallpaper</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -69,14 +69,18 @@
             android:key="@string/settings_clock_time_visible_key"
             android:defaultValue="true"
             android:title="@string/settings_clock_time_visible" />
-        <SwitchPreference
-            android:key="@string/settings_clock_show_seconds_key"
-            android:defaultValue="true"
-            android:title="@string/settings_clock_show_seconds" />
+        <EditTextPreference
+            android:key="@string/settings_clock_time_format_key"
+            android:defaultValue="h:mm:ss"
+            android:title="@string/settings_clock_time_format" />
         <SwitchPreference
             android:key="@string/settings_clock_date_visible_key"
             android:defaultValue="true"
             android:title="@string/settings_clock_date_visible" />
+        <EditTextPreference
+            android:key="@string/settings_clock_date_format_key"
+            android:defaultValue="yyyy-MM-dd"
+            android:title="@string/settings_clock_date_format" />
         <SwitchPreference
             android:key="@string/settings_clock_flip_date_time_key"
             android:defaultValue="false"


### PR DESCRIPTION
Currently the only options to change the format of date and time are "set localized date and time" and "show seconds." This PR adds two options "date-format" and "time-format" which replace the default dateFMT = "yyyy-MM-dd" and timeFMT = "HH:mm" strings, allowing the user to customize the UI further. 
This PR also invalidates the "show seconds" option (this functionality would now be done by appending ":ss" or similar to time-format option), so I have "soft removed" it from the options menu, but it is still in the code.

If this PR is going to be merged, I will make another commit updating the documentation files accordingly.

This is my first time doing a PR through GitHub, so let me know if I completely messed something up :)

Thank you.