### PR TITLE
fix #246

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.ViewCompat
 import de.jrpie.android.launcher.Application
 import de.jrpie.android.launcher.actions.Action
 import de.jrpie.android.launcher.actions.Gesture
@@ -55,6 +56,12 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
         binding = ActivityHomeBinding.inflate(layoutInflater)
 
         setContentView(binding.root)
+
+        // The widget container should extend below the status and navigation bars,
+        // so let's set an empty WindowInsetsListener to prevent it from being moved.
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            windowInsets
+        }
 
         binding.buttonFallbackSettings.setOnClickListener {
             LauncherAction.SETTINGS.invoke(this)

--- a/app/src/main/res/layout/widget_clock.xml
+++ b/app/src/main/res/layout/widget_clock.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:longClickable="false"
-    android:fitsSystemWindows="true"
     tools:context=".ui.widgets.ClockView">
 
     <TextClock

--- a/app/src/main/res/layout/widget_debug_info.xml
+++ b/app/src/main/res/layout/widget_debug_info.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:longClickable="false"
-    android:fitsSystemWindows="true"
     tools:context=".ui.widgets.DebugInfoView">
 
     <TextView


### PR DESCRIPTION
### Issue:

Built-in widgets (clock/date, debug info) shift position by the status bar height when performing slight upward swipes on the home screen as seen in [#246](https://github.com/jrpie/launcher/issues/246).

### Root Cause:

`HomeActivity` was missing a `ViewCompat.setOnApplyWindowInsetsListener` that prevents `fitsSystemWindows="true"` from automatically applying status bar padding when window insets change during swipe gestures. This listener was already correctly implemented in `WidgetPanelActivity` and `ManageWidgetsActivity`, but was absent from `HomeActivity`.

### Note:

The empty `setOnApplyWindowInsetsListener` pattern is now duplicated across multiple activities; perhaps next work on extracting a shared helper (e.g., an extension or base class method) to keep this behavior consistent and easier to maintain.
