### PR TITLE
feat: glowy terminal colors

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -67,6 +67,7 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "flip_date_time", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "localized", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "show_seconds", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "text_shadow", type = boolean.class, defaultValue = "false"),
                 }),
                 @PreferenceGroup(name = "display", prefix = "settings_display_", suffix = "_key", value = {
                         @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/theme/ColorTheme.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/theme/ColorTheme.kt
@@ -39,7 +39,7 @@ enum class ColorTheme(
     GREEN(
         R.style.colorThemeGreen,
         R.string.settings_theme_color_theme_item_green,
-        R.style.textShadow,
+        R.style.textShadowGreen,
         { true },
         ColorMatrix().apply {
             setSaturation(0f)
@@ -57,7 +57,7 @@ enum class ColorTheme(
     AMBER(
         R.style.colorThemeAmber,
         R.string.settings_theme_color_theme_item_amber,
-        R.style.textShadow,
+        R.style.textShadowAmber,
         { true },
         ColorMatrix().apply {
             setSaturation(0f)

--- a/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
@@ -78,6 +78,10 @@ class ClockView(
 
         binding.clockUpperView.setTextColor(LauncherPreferences.clock().color())
         binding.clockLowerView.setTextColor(LauncherPreferences.clock().color())
+        val shadowRadius = if (LauncherPreferences.clock().textShadow()) 12f else 0f
+        val shadowColor = if (LauncherPreferences.clock().textShadow()) LauncherPreferences.clock().color() else 0
+        binding.clockUpperView.setShadowLayer(shadowRadius, 0f, 0f, shadowColor)
+        binding.clockLowerView.setShadowLayer(shadowRadius, 0f, 0f, shadowColor)
 
         binding.clockLowerView.format24Hour = lowerFormat
         binding.clockUpperView.format24Hour = upperFormat

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -150,6 +150,7 @@
     <string name="settings_clock_date_visible_key" translatable="false">clock.date_visible</string>
     <string name="settings_clock_localized_key" translatable="false">clock.date_localized</string>
     <string name="settings_clock_flip_date_time_key" translatable="false">clock.date_time_flip</string>
+    <string name="settings_clock_text_shadow_key" translatable="false">clock.text_shadow</string>
 
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,7 @@
     <string name="settings_clock_localized">Use localized date format</string>
     <string name="settings_clock_show_seconds">Show seconds</string>
     <string name="settings_clock_flip_date_time">Flip date and time</string>
+    <string name="settings_clock_text_shadow">Clock text glow</string>
 
     <string name="settings_theme_wallpaper">Choose a wallpaper</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
 
     <!-- to force black textcolor for buttons -->
     <style name="buttonBlackText" parent="@style/Widget.AppCompat.Button.Colored">
-        <item name="android:textColor">#000000</item>
+        <item name="android:textColor">#000</item>
         <!--<item name="colorButtonNormal">?colorAccent</item>-->
     </style>
 
@@ -57,7 +57,7 @@
     <style name="colorThemeAmber">
         <item name="colorPrimary">@color/darkTheme_background_color</item>
         <item name="colorPrimaryDark">@color/darkTheme_background_color</item>
-        <item name="colorAccent">#FFB000</item>
+        <item name="colorAccent">#ffb000</item>
         <item name="android:buttonStyle">@style/buttonBlackText</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
         <item name="cardBackgroundColor">@color/cardview_dark_background</item>
@@ -104,6 +104,16 @@
         <item name="android:shadowColor">#aaa</item>
     </style>
 
+    <style name="textShadowGreen" parent="textShadow">
+        <item name="android:shadowColor">#0f0</item>
+        <item name="android:shadowRadius">12</item>
+    </style>
+
+    <style name="textShadowAmber" parent="textShadow">
+        <item name="android:shadowColor">#ffb000</item>
+        <item name="android:shadowRadius">12</item>
+    </style>
+
 
     <style name="backgroundWallpaper">
         <item name="android:statusBarColor">@android:color/transparent</item>
@@ -148,7 +158,7 @@
     </style>
 
     <style name="AlertDialogCustom" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:color">#000000</item>
+        <item name="android:color">#000</item>
         <item name="android:textColor">@color/text_color_toggle</item>
         <item name="android:shadowRadius">0</item>
         <item name="android:shadowDx">0</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,6 +85,10 @@
             android:key="@string/settings_clock_flip_date_time_key"
             android:defaultValue="false"
             android:title="@string/settings_clock_flip_date_time" />
+        <SwitchPreference
+            android:key="@string/settings_clock_text_shadow_key"
+            android:defaultValue="false"
+            android:title="@string/settings_clock_text_shadow" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
### Feature

Makes the amber and green "terminal" font colors glow when "Text shadow" is toggled on.

### Freshness

I made all the hex codes in this file truncated to their three-character variant where possible, and made them all lowercase for consistency with the rest of the codebase and to save pinky fingers.

### Future

Minor tweak for the future would be to adjust the left padding/margin for items such as app titles so the glow doesn't have a visible cutoff at the bounding edge.

### Pics or it didn't happen

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/205c2b11-f843-48e2-ab5f-d27113ebdc10" />

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/fcb4ed46-0fc7-4c02-9586-9b07f89f1cc4" />

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/96070ce1-b776-4622-85fb-2a0ba33f8355" />

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/d15b27d3-89eb-406a-b798-dfaac575b767" />

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/9598dbeb-63ea-47a1-aba2-5800666c83a6" />