### PR TITLE
optimize at build time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 # Add project specific ProGuard rules here.
--dontobfuscate
--dontoptimize
+#-dontobfuscate # Use temporarily to turn off identifier minification
+#-dontoptimize # Use temporarily to turn off optimization
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.kts.
 #

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,5 +1,5 @@
 # Add project specific ProGuard rules here.
-#-dontobfuscate # Use temporarily to turn off identifier minification
+-dontobfuscate # Use temporarily to turn off identifier minification
 #-dontoptimize # Use temporarily to turn off optimization
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.kts.

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 org.gradle.configuration-cache=true
+# Required for `isShrinkResources = true` if AGP<9.0.0
+android.r8.optimizedResourceShrinking=true


### PR DESCRIPTION
This PR comes about after seeing [optimizations turned off](https://github.com/jrpie/launcher/commit/757486771d151495ba8d8f4a7ab5daa15fb6d99c#r177379459) in the build settings.

From the Android build optimization documentation

> To enable app optimization, set `isMinifyEnabled = true` (for code optimization)

Check. We've already done this.

> and `isShrinkResources = true` (for resource optimization) in your release build's app-level build script as shown in the following code. We recommend that you always enable both settings. [1](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization)

Enabled in this commit.

This cuts the size of the debug build of the app in half (see below [debug] vs [Optimized]).

<img width="1344" height="2992" alt="Screenshot_20260216-211103" src="https://github.com/user-attachments/assets/d221d67a-bf13-479f-a4f4-8d563fdcd541" />

Would love to see how this impacts the production size of the app but my little brain isn't figuring out how to get that build from Android Studio to my device right now, alls I can get over are the debug builds. Sucks being dumb. Stay in school, kids.