### PR TITLE
fix/serif-monospace

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/theme/Font.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/theme/Font.kt
@@ -12,7 +12,7 @@ enum class Font(val id: Int) {
     HACK(R.style.fontHack),
     SYSTEM_DEFAULT(R.style.fontSystemDefault),
     SANS_SERIF(R.style.fontSansSerif),
-    SERIF(R.style.fontSerifMonospace),
+    SERIF(R.style.fontSerif),
     MONOSPACE(R.style.fontMonospace),
     SERIF_MONOSPACE(R.style.fontSerifMonospace),
     ;


### PR DESCRIPTION
Like a clean and simple Serif font? Sucks to be you because all you'r…e going to get is another Serif Monospace masquerading as "Serif"...

### UNTIL NOW

With this PR users can now select the "Serif" font and get the Serif font.