### PR TITLE
increase dark theme accent color from #444 to #888 for visibility

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="finnmglasTheme_text_color">#fff</color>
 
     <color name="darkTheme_background_color">#000</color>
-    <color name="darkTheme_accent_color">#444</color>
+    <color name="darkTheme_accent_color">#888</color>
     <color name="darkTheme_text_color">#fff</color>
 
     <color name="lightTheme_background_color">#fff</color>


### PR DESCRIPTION
The previous \#444 accent color had very poor contrast against the black background, causing Switch toggles to appear dim when enabled and bright when disabled. It also made the menu section titles very difficult/impossible to read. \#888 is much brighter without being overly bright, so visibility is improved.

I'm also now noticing the toggles get brighter when they're set to disabled in the Dark Theme. I'll work on sorting that out eventually.