### PR TITLE
fix: only delete AppWidget from prefs when provider app is truly uninstalled

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/widgets/AppWidget.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/widgets/AppWidget.kt
@@ -4,15 +4,19 @@ import android.app.Activity
 import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
+import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.util.DisplayMetrics
+import android.util.Log
 import android.util.SizeF
 import android.view.View
 import de.jrpie.android.launcher.Application
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+private const val LOG_TAG = "AppWidget"
 
 @Serializable
 @SerialName("widget:app")
@@ -77,10 +81,18 @@ class AppWidget(
     }
 
     override fun createView(activity: Activity): AppWidgetHostView? {
-        val providerInfo = activity.getAppWidgetManager().getAppWidgetInfo(id) ?: return null
-        /* TODO: if providerInfo is null, the corresponding app was probably uninstalled.
-            There does not seem to be a way to recover the widget when the app is installed again,
-            hence it should be deleted. */
+        val providerInfo = activity.getAppWidgetManager().getAppWidgetInfo(id) ?: run {
+            try {
+                @Suppress("DEPRECATION")
+                activity.packageManager.getApplicationInfo(packageName ?: "", PackageManager.GET_DISABLED_COMPONENTS)
+                // Package is installed but provider is temporarily unavailable (e.g. disabled).
+                Log.d(LOG_TAG, "Widget provider temporarily unavailable: $packageName (id=$id)")
+            } catch (e: PackageManager.NameNotFoundException) {
+                // Package is gone; clean up the orphaned widget entry.
+                delete(activity)
+            }
+            return null
+        }
 
         val view = activity.getAppWidgetHost()
             .createView(activity, this.id, providerInfo)


### PR DESCRIPTION
To fix #167.

When `getAppWidgetInfo()` returns "null" in `createView()`, this now checks the `PackageManager` before deleting the widget.

_If_ the package is still installed but disabled/force-stopped, the widget is _preserved_ (and it gives a Log.d).

This allows the widget to be recoverable when the app is re-enabled. The widget _only_ gets deleted when a `NameNotFoundException` confirms the app is gone from the system.