### PR TITLE
feat/distraction free app list

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import de.jrpie.android.launcher.R;
 import de.jrpie.android.launcher.actions.lock.LockMethod;
+import de.jrpie.android.launcher.preferences.list.AppListMode;
 import de.jrpie.android.launcher.preferences.list.AppNameFormat;
 import de.jrpie.android.launcher.preferences.list.ListLayout;
 import de.jrpie.android.launcher.preferences.serialization.MapAbstractAppInfoStringPreferenceSerializer;
@@ -43,7 +44,10 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 @PreferenceGroup(name = "list", prefix = "settings_list_", suffix = "_key", value = {
                         @Preference(name = "layout", type = ListLayout.class, defaultValue = "DEFAULT"),
                         @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "app_name_format", type = AppNameFormat.class, defaultValue = "DEFAULT")
+                        @Preference(name = "app_name_format", type = AppNameFormat.class, defaultValue = "DEFAULT"),
+                        @Preference(name = "app_list_mode", type = AppListMode.class, defaultValue = "NORMAL"),
+                        @Preference(name = "limit_results", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "limit_results_count", type = int.class, defaultValue = "5")
                 }),
                 @PreferenceGroup(name = "gestures", prefix = "settings_gesture_", suffix = "_key", value = {
                 }),

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppListMode.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/list/AppListMode.kt
@@ -1,0 +1,8 @@
+package de.jrpie.android.launcher.preferences.list
+
+@Suppress("unused")
+enum class AppListMode {
+    NORMAL,
+    HIDE_UNTIL_SEARCH,
+    NEVER_SHOW
+}

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
@@ -207,12 +207,6 @@ class AppsRecyclerAdapter(
         appsListDisplayed.clear()
         apps.value?.let { appsListDisplayed.addAll(appFilter(it)) }
 
-        // Limit results (before auto-launch so the 1-match check reflects the capped list)
-        if (LauncherPreferences.list().limitResults()) {
-            val limit = LauncherPreferences.list().limitResultsCount().coerceAtLeast(1)
-            if (appsListDisplayed.size > limit) appsListDisplayed.subList(limit, appsListDisplayed.size).clear()
-        }
-
         if (triggerAutoLaunch &&
             appsListDisplayed.size == 1
             && intention == AbstractListActivity.Companion.Intention.VIEW
@@ -227,7 +221,12 @@ class AppsRecyclerAdapter(
             inputMethodManager.hideSoftInputFromWindow(View(activity).windowToken, 0)
         }
 
-        // Visibility mode (after auto-launch — display only, never suppresses auto-launch)
+        // Limit results (display only — after auto-launch so it never affects launch behaviour)
+        if (LauncherPreferences.list().limitResults()) {
+            val limit = LauncherPreferences.list().limitResultsCount().coerceAtLeast(1)
+            if (appsListDisplayed.size > limit) appsListDisplayed.subList(limit, appsListDisplayed.size).clear()
+        }
+
         val mode = LauncherPreferences.list().appListMode()
         if (mode == AppListMode.NEVER_SHOW ||
             (mode == AppListMode.HIDE_UNTIL_SEARCH && appFilter.query.isEmpty())) {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
@@ -21,6 +21,7 @@ import de.jrpie.android.launcher.apps.AppFilter
 import de.jrpie.android.launcher.apps.AppInfo
 import de.jrpie.android.launcher.apps.DetailedAppInfo
 import de.jrpie.android.launcher.preferences.LauncherPreferences
+import de.jrpie.android.launcher.preferences.list.AppListMode
 import de.jrpie.android.launcher.preferences.list.AppNameFormat
 import de.jrpie.android.launcher.preferences.list.ListLayout
 import de.jrpie.android.launcher.ui.list.AbstractListActivity
@@ -206,6 +207,12 @@ class AppsRecyclerAdapter(
         appsListDisplayed.clear()
         apps.value?.let { appsListDisplayed.addAll(appFilter(it)) }
 
+        // Limit results (before auto-launch so the 1-match check reflects the capped list)
+        if (LauncherPreferences.list().limitResults()) {
+            val limit = LauncherPreferences.list().limitResultsCount().coerceAtLeast(1)
+            if (appsListDisplayed.size > limit) appsListDisplayed.subList(limit, appsListDisplayed.size).clear()
+        }
+
         if (triggerAutoLaunch &&
             appsListDisplayed.size == 1
             && intention == AbstractListActivity.Companion.Intention.VIEW
@@ -218,6 +225,13 @@ class AppsRecyclerAdapter(
             val inputMethodManager =
                 activity.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
             inputMethodManager.hideSoftInputFromWindow(View(activity).windowToken, 0)
+        }
+
+        // Visibility mode (after auto-launch — display only, never suppresses auto-launch)
+        val mode = LauncherPreferences.list().appListMode()
+        if (mode == AppListMode.NEVER_SHOW ||
+            (mode == AppListMode.HIDE_UNTIL_SEARCH && appFilter.query.isEmpty())) {
+            appsListDisplayed.clear()
         }
 
         notifyDataSetChanged()

--- a/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
@@ -9,6 +9,7 @@ import de.jrpie.android.launcher.R
 import de.jrpie.android.launcher.actions.lock.LockMethod
 import de.jrpie.android.launcher.actions.openAppsList
 import de.jrpie.android.launcher.preferences.LauncherPreferences
+import de.jrpie.android.launcher.preferences.list.AppListMode
 import de.jrpie.android.launcher.preferences.theme.ColorTheme
 import de.jrpie.android.launcher.setDefaultHomeScreen
 import de.jrpie.android.launcher.ui.widgets.manage.ManageWidgetPanelsActivity
@@ -25,7 +26,7 @@ class SettingsFragmentLauncher : PreferenceFragmentCompat() {
 
     private var sharedPreferencesListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, prefKey ->
-            if (prefKey?.startsWith("clock.") == true) {
+            if (prefKey?.startsWith("clock.") == true || prefKey?.startsWith("list.") == true) {
                 updateVisibility()
             }
         }
@@ -47,6 +48,15 @@ class SettingsFragmentLauncher : PreferenceFragmentCompat() {
             LauncherPreferences.apps().keys().hidePausedApps()
         )
         hidePausedApps?.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+
+        val neverShow = LauncherPreferences.list().appListMode() == AppListMode.NEVER_SHOW
+        val limitEnabled = LauncherPreferences.list().limitResults()
+
+        findPreference<androidx.preference.Preference>(LauncherPreferences.list().keys().layout())?.isVisible = !neverShow
+        findPreference<androidx.preference.Preference>(LauncherPreferences.list().keys().appNameFormat())?.isVisible = !neverShow
+        findPreference<androidx.preference.Preference>(LauncherPreferences.list().keys().reverseLayout())?.isVisible = !neverShow
+        findPreference<androidx.preference.Preference>(LauncherPreferences.list().keys().limitResults())?.isVisible = !neverShow
+        findPreference<androidx.preference.PreferenceCategory>("list.limit_results_count_container")?.isVisible = !neverShow && limitEnabled
     }
 
     override fun onStart() {

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -24,6 +24,7 @@
     <string name="settings_list_app_list_mode_key" translatable="false">list.app_list_mode</string>
     <string name="settings_list_limit_results_key" translatable="false">list.limit_results</string>
     <string name="settings_list_limit_results_count_key" translatable="false">list.limit_results_count</string>
+    <string name="settings_list_limit_results_count_container_key" translatable="false">list.limit_results_count_container</string>
     <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
 
     <!-- values of de.jrpie.android.launcher.preferences.list.ListLayout -->

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -21,6 +21,9 @@
     <string name="settings_list_layout_key" translatable="false">list.layout</string>
     <string name="settings_list_app_name_format_key" translatable="false">list.app_name_format</string>
     <string name="settings_list_reverse_layout_key" translatable="false">list.reverse_layout</string>
+    <string name="settings_list_app_list_mode_key" translatable="false">list.app_list_mode</string>
+    <string name="settings_list_limit_results_key" translatable="false">list.limit_results</string>
+    <string name="settings_list_limit_results_count_key" translatable="false">list.limit_results_count</string>
     <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
 
     <!-- values of de.jrpie.android.launcher.preferences.list.ListLayout -->
@@ -49,6 +52,19 @@
         <item>@string/settings_list_app_name_format_item_default</item>
         <item>@string/settings_list_app_name_format_item_uppercase</item>
         <item>@string/settings_list_app_name_format_item_lowercase</item>
+    </string-array>
+
+    <!-- values of de.jrpie.android.launcher.preferences.list.AppListMode -->
+    <string-array name="settings_list_app_list_mode_values" translatable="false">
+        <item>NORMAL</item>
+        <item>HIDE_UNTIL_SEARCH</item>
+        <item>NEVER_SHOW</item>
+    </string-array>
+
+    <string-array name="settings_list_app_list_mode_items" translatable="false">
+        <item>@string/settings_list_app_list_mode_item_normal</item>
+        <item>@string/settings_list_app_list_mode_item_hide_until_search</item>
+        <item>@string/settings_list_app_list_mode_item_never_show</item>
     </string-array>
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,13 @@
     <string name="settings_list_app_name_format_item_uppercase">Uppercase</string>
     <string name="settings_list_app_name_format_item_lowercase">Lowercase</string>
 
+    <string name="settings_list_app_list_mode">App list visibility</string>
+    <string name="settings_list_app_list_mode_item_normal">Show all apps</string>
+    <string name="settings_list_app_list_mode_item_hide_until_search">Hide until search</string>
+    <string name="settings_list_app_list_mode_item_never_show">Never show</string>
+    <string name="settings_list_limit_results">Limit results</string>
+    <string name="settings_list_limit_results_count">Maximum results</string>
+
     <!--
       -
       - Settings : Meta

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,7 +197,7 @@
     <string name="settings_apps_hide_private_space_apps">Hide private space from app list</string>
     <string name="settings_list_layout">Layout of app list</string>
     <string name="settings_list_reverse_layout">Reverse the app list</string>
-    <string name="settings_list_app_name_format">Names of Apps</string>
+    <string name="settings_list_app_name_format">Names of apps</string>
 
     <string name="settings_list_layout_item_default">Default</string>
     <string name="settings_list_layout_item_text">Text</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -185,6 +185,29 @@
             android:title="@string/settings_list_reverse_layout"
             android:defaultValue="false" />
 
+        <DropDownPreference
+            android:key="@string/settings_list_app_list_mode_key"
+            android:title="@string/settings_list_app_list_mode"
+            android:entries="@array/settings_list_app_list_mode_items"
+            android:entryValues="@array/settings_list_app_list_mode_values"
+            android:defaultValue="NORMAL"
+            app:useSimpleSummaryProvider="true" />
+
+        <SwitchPreference
+            android:key="@string/settings_list_limit_results_key"
+            android:title="@string/settings_list_limit_results"
+            android:defaultValue="false" />
+
+        <PreferenceCategory
+            android:dependency="@string/settings_list_limit_results_key"
+            app:allowDividerAbove="false">
+            <SeekBarPreference
+                android:key="@string/settings_list_limit_results_count_key"
+                android:title="@string/settings_list_limit_results_count"
+                android:defaultValue="5"
+                android:min="1"
+                android:max="20" />
+        </PreferenceCategory>
 
     </PreferenceCategory>
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -205,7 +205,7 @@
                 android:key="@string/settings_list_limit_results_count_key"
                 android:title="@string/settings_list_limit_results_count"
                 android:defaultValue="5"
-                android:min="1"
+                app:min="1"
                 android:max="20"
                 app:showSeekBarValue="true" />
         </PreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -146,6 +146,14 @@
         android:title="@string/settings_launcher_section_apps"
         app:allowDividerAbove="false">
 
+        <DropDownPreference
+            android:key="@string/settings_list_app_list_mode_key"
+            android:title="@string/settings_list_app_list_mode"
+            android:entries="@array/settings_list_app_list_mode_items"
+            android:entryValues="@array/settings_list_app_list_mode_values"
+            android:defaultValue="NORMAL"
+            app:useSimpleSummaryProvider="true" />
+
         <Preference
             android:key="@string/settings_apps_hidden_key"
             android:title="@string/settings_apps_hidden" />
@@ -185,28 +193,21 @@
             android:title="@string/settings_list_reverse_layout"
             android:defaultValue="false" />
 
-        <DropDownPreference
-            android:key="@string/settings_list_app_list_mode_key"
-            android:title="@string/settings_list_app_list_mode"
-            android:entries="@array/settings_list_app_list_mode_items"
-            android:entryValues="@array/settings_list_app_list_mode_values"
-            android:defaultValue="NORMAL"
-            app:useSimpleSummaryProvider="true" />
-
         <SwitchPreference
             android:key="@string/settings_list_limit_results_key"
             android:title="@string/settings_list_limit_results"
             android:defaultValue="false" />
 
         <PreferenceCategory
-            android:dependency="@string/settings_list_limit_results_key"
+            android:key="@string/settings_list_limit_results_count_container_key"
             app:allowDividerAbove="false">
             <SeekBarPreference
                 android:key="@string/settings_list_limit_results_count_key"
                 android:title="@string/settings_list_limit_results_count"
                 android:defaultValue="5"
                 android:min="1"
-                android:max="20" />
+                android:max="20"
+                app:showSeekBarValue="true" />
         </PreferenceCategory>
 
     </PreferenceCategory>


### PR DESCRIPTION
I am delighted to announce I have a solution to close #240. :partying_face: 

## What's new

Adds two opt-in settings under **Apps** in Settings>LAUNCHER:

- **Limit results** [toggle + seekbar (default is 5, range is 1–20) that caps how many apps are shown]
- **App list visibility** is a 3-state dropdown:
  - *Show all apps* (default, existing behavior)
  - *Hide until search* (list is empty until the user types)
  - *Never show* (list is always empty; relies entirely on auto-launch)

When *Never show* is active, the Layout, Names of Apps, Reverse layout, Limit results, and Maximum results settings are hidden. Maximum results also hides when Limit results is toggled off.

Auto-launch is unaffected by both settings. It fires whenever exactly one app matches the search query, using the full (uncapped) result set (the existing behavior is unaffected). The display cap is purely cosmetic.

## This PR in action

> Video resolution is crap because I recorded it at 25% native resolution thinking the final file would be small enough to upload directly here in the PR. I was wrong.

[![Video Thumbnail](https://img.youtube.com/vi/utKtv04gTY4/0.jpg)](https://youtube.com/shorts/utKtv04gTY4?feature=share)

## Want some more reading on what else went into this?

> Kind of a preview into the mental gymnastics I did along the way.

As I was building this I kept on finding new edge cases to handle:

### Auto-launch must fire regardless of display state

The initial implementation applied the result cap *before* the auto-launch check, which meant setting Maximum results to 1 would cause auto-launch to fire on the first displayed app rather than a true single match. So, typing "g" would immediately launch Gmail. I fixed this by moving the limit truncation to *after* the auto-launch check. The auto-launch check always sees the full filtered list; the cap is display/cosmetic-only.

### SeekBar minimum not enforced on all API levels

`android:min="1"` seems to be silently ignored by some versions of the AndroidX Preference library, leaving 0 selectable in the UI and still showing a single list entry despite "0" being set. Fixed by using `app:min="1"` instead.

### Visibility suppression and limit are independent

When *Never show* or *Hide until search* clears the display list, it happens *after* both auto-launch and the limit truncation. This means the limit is irrelevant in those modes (the list gets cleared anyway), but auto-launch still fires correctly — a single true match launches the app even when nothing is ever visible on screen.

### Settings order

I moved *App list visibility* to the top of the Apps section since it controls whether many of the remaining settings below it display or not. If the user doesn't want any apps to show, most of the other settings don't matter and can go away as mentioned just above.

### Live visibility updates

I expanded the `SharedPreferences` listener to react to `list.` prefix changes so switching visibility modes shows or hides the relevant settings without having to exit the menu and come back to see the changes.

### Seekbar value indicator

I added a nice numeric display along with the slider so the user knows exactly how many apps they're setting as the maximum to display. I thought about adding a numeric to the Edge width slider but figured that was out of the scope of this PR. If tablet people using this app functionally need more than the 1-20 maximum app list limit, we could change it down the road, but 20 seems like a reasonable upper limit to me.

Thanks for considering and @jrpie let me know what I can do to help you more with PR reviews or working through the backlog of issues.