### PR TITLE
feat/close menu by reverse gesture

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
@@ -2,8 +2,12 @@ package de.jrpie.android.launcher.ui.list
 
 import android.os.Build
 import android.os.Bundle
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.window.OnBackInvokedDispatcher
+import androidx.core.view.GestureDetectorCompat
 import androidx.appcompat.content.res.AppCompatResources
 import de.jrpie.android.launcher.Application
 import de.jrpie.android.launcher.R
@@ -117,6 +121,33 @@ class AppListActivity : AbstractListActivity() {
                 finish()
             }
         }
+
+        // Dismiss by swiping down on the title or ✕ button.
+        // The settings gear (list_settings) is intentionally excluded.
+        val minFlingVelocity = ViewConfiguration.get(this).scaledMinimumFlingVelocity
+        val dismissDetector = GestureDetectorCompat(
+            this,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onFling(
+                    e1: MotionEvent?,
+                    e2: MotionEvent,
+                    velocityX: Float,
+                    velocityY: Float
+                ): Boolean {
+                    if (velocityY > minFlingVelocity) {
+                        finish()
+                        return true
+                    }
+                    return false
+                }
+            }
+        )
+        val dismissTouchListener = View.OnTouchListener { _, event ->
+            dismissDetector.onTouchEvent(event)
+            false // don't consume — click listener on list_close still fires normally
+        }
+        binding.listHeading.setOnTouchListener(dismissTouchListener)
+        binding.listClose.setOnTouchListener(dismissTouchListener)
     }
 
     override fun adjustLayout() {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
@@ -141,12 +141,18 @@ class AppListActivity : AbstractListActivity() {
                 }
             }
         )
-        val dismissTouchListener = View.OnTouchListener { _, event ->
+        // listHeading is a non-clickable TextView — must return true for ACTION_DOWN
+        // so Android keeps delivering ACTION_MOVE and ACTION_UP to this view.
+        binding.listHeading.setOnTouchListener { _, event ->
             dismissDetector.onTouchEvent(event)
-            false // don't consume — click listener on list_close still fires normally
+            event.actionMasked == MotionEvent.ACTION_DOWN
         }
-        binding.listHeading.setOnTouchListener(dismissTouchListener)
-        binding.listClose.setOnTouchListener(dismissTouchListener)
+        // listClose is clickable — its own onTouchEvent returns true for ACTION_DOWN,
+        // so the gesture sequence is already kept alive without consuming here.
+        binding.listClose.setOnTouchListener { _, event ->
+            dismissDetector.onTouchEvent(event)
+            false
+        }
     }
 
     override fun adjustLayout() {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
@@ -141,14 +141,10 @@ class AppListActivity : AbstractListActivity() {
                 }
             }
         )
-        // listHeading is a non-clickable TextView — must return true for ACTION_DOWN
-        // so Android keeps delivering ACTION_MOVE and ACTION_UP to this view.
         binding.listHeading.setOnTouchListener { _, event ->
             dismissDetector.onTouchEvent(event)
             event.actionMasked == MotionEvent.ACTION_DOWN
         }
-        // listClose is clickable — its own onTouchEvent returns true for ACTION_DOWN,
-        // so the gesture sequence is already kept alive without consuming here.
         binding.listClose.setOnTouchListener { _, event ->
             dismissDetector.onTouchEvent(event)
             false

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/AppListActivity.kt
@@ -7,7 +7,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.window.OnBackInvokedDispatcher
-import androidx.core.view.GestureDetectorCompat
 import androidx.appcompat.content.res.AppCompatResources
 import de.jrpie.android.launcher.Application
 import de.jrpie.android.launcher.R
@@ -125,7 +124,7 @@ class AppListActivity : AbstractListActivity() {
         // Dismiss by swiping down on the title or ✕ button.
         // The settings gear (list_settings) is intentionally excluded.
         val minFlingVelocity = ViewConfiguration.get(this).scaledMinimumFlingVelocity
-        val dismissDetector = GestureDetectorCompat(
+        val dismissDetector = GestureDetector(
             this,
             object : GestureDetector.SimpleOnGestureListener() {
                 override fun onFling(

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -135,8 +135,8 @@ class ListFragmentApps : Fragment(), UIObject {
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
         val dismissThresholdPx = (40 * resources.displayMetrics.density).toInt()
         var overscrollDistance = 0f
-        // Latches true if the gesture left the boundary at any point — prevents
-        // a swipe-up-then-back-down from accidentally dismissing.
+        // Latches true if the gesture left the boundary at any point.
+        // Prevents a swipe-up-then-back-down from accidentally dismissing.
         var gestureLeftBoundary = false
         val dismissDetector = GestureDetector(
             requireContext(),
@@ -193,7 +193,7 @@ class ListFragmentApps : Fragment(), UIObject {
         dismissTouchListener = object : RecyclerView.SimpleOnItemTouchListener() {
             override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
                 dismissDetector.onTouchEvent(e)
-                return false // never consume — RecyclerView handles scrolling normally
+                return false
             }
         }
         binding.listAppsRview.addOnItemTouchListener(dismissTouchListener!!)

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -129,9 +129,40 @@ class ListFragmentApps : Fragment(), UIObject {
         // Standard layout: boundary is the top (canScrollVertically(-1) == false).
         // Reversed layout: boundary is the visual bottom (canScrollVertically(1) == false).
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
+        val dismissThresholdPx = (40 * resources.displayMetrics.density).toInt()
+        var overscrollDistance = 0f
         val dismissDetector = GestureDetector(
             requireContext(),
             object : GestureDetector.SimpleOnGestureListener() {
+                override fun onDown(e: MotionEvent): Boolean {
+                    overscrollDistance = 0f
+                    return false
+                }
+
+                override fun onScroll(
+                    e1: MotionEvent?,
+                    e2: MotionEvent,
+                    distanceX: Float,
+                    distanceY: Float
+                ): Boolean {
+                    val atBoundary = if (LauncherPreferences.list().reverseLayout())
+                        !binding.listAppsRview.canScrollVertically(1)
+                    else
+                        !binding.listAppsRview.canScrollVertically(-1)
+
+                    if (atBoundary && distanceY < 0) {
+                        // distanceY < 0 means finger is moving down
+                        overscrollDistance -= distanceY
+                        if (overscrollDistance > dismissThresholdPx) {
+                            requireActivity().finish()
+                            return true
+                        }
+                    } else {
+                        overscrollDistance = 0f
+                    }
+                    return false
+                }
+
                 override fun onFling(
                     e1: MotionEvent?,
                     e2: MotionEvent,

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -132,11 +132,15 @@ class ListFragmentApps : Fragment(), UIObject {
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
         val dismissThresholdPx = (40 * resources.displayMetrics.density).toInt()
         var overscrollDistance = 0f
+        // Latches true if the gesture left the boundary at any point — prevents
+        // a swipe-up-then-back-down from accidentally dismissing.
+        var gestureLeftBoundary = false
         val dismissDetector = GestureDetector(
             requireContext(),
             object : GestureDetector.SimpleOnGestureListener() {
                 override fun onDown(e: MotionEvent): Boolean {
                     overscrollDistance = 0f
+                    gestureLeftBoundary = false
                     return false
                 }
 
@@ -148,15 +152,20 @@ class ListFragmentApps : Fragment(), UIObject {
                 ): Boolean {
                     val atBoundary = !binding.listAppsRview.canScrollVertically(-1)
 
-                    if (atBoundary && distanceY < 0) {
+                    if (!atBoundary) {
+                        gestureLeftBoundary = true
+                        overscrollDistance = 0f
+                        return false
+                    }
+                    if (gestureLeftBoundary) return false
+
+                    if (distanceY < 0) {
                         // distanceY < 0 means finger is moving down
                         overscrollDistance -= distanceY
                         if (overscrollDistance > dismissThresholdPx) {
                             requireActivity().finish()
                             return true
                         }
-                    } else {
-                        overscrollDistance = 0f
                     }
                     return false
                 }
@@ -167,6 +176,7 @@ class ListFragmentApps : Fragment(), UIObject {
                     velocityX: Float,
                     velocityY: Float
                 ): Boolean {
+                    if (gestureLeftBoundary) return false
                     val atBoundary = !binding.listAppsRview.canScrollVertically(-1)
 
                     if (atBoundary && velocityY > minFlingVelocity) {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.view.GestureDetectorCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -130,7 +129,7 @@ class ListFragmentApps : Fragment(), UIObject {
         // Standard layout: boundary is the top (canScrollVertically(-1) == false).
         // Reversed layout: boundary is the visual bottom (canScrollVertically(1) == false).
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
-        val dismissDetector = GestureDetectorCompat(
+        val dismissDetector = GestureDetector(
             requireContext(),
             object : GestureDetector.SimpleOnGestureListener() {
                 override fun onFling(

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -71,6 +71,12 @@ class ListFragmentApps : Fragment(), UIObject {
 
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        dismissTouchListener?.let { binding.listAppsRview.removeOnItemTouchListener(it) }
+        dismissTouchListener = null
+    }
+
     override fun onStop() {
         super.onStop()
         LauncherPreferences.getSharedPreferences()
@@ -126,9 +132,6 @@ class ListFragmentApps : Fragment(), UIObject {
         }
 
         // Dismiss the app list by swiping down when already at the top scroll boundary.
-        // canScrollVertically(-1) == false means the list cannot scroll further upward,
-        // i.e. the top of the content is visible. This is the dismiss boundary for both
-        // standard and reversed layouts.
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
         val dismissThresholdPx = (40 * resources.displayMetrics.density).toInt()
         var overscrollDistance = 0f
@@ -160,7 +163,6 @@ class ListFragmentApps : Fragment(), UIObject {
                     if (gestureLeftBoundary) return false
 
                     if (distanceY < 0) {
-                        // distanceY < 0 means finger is moving down
                         overscrollDistance -= distanceY
                         if (overscrollDistance > dismissThresholdPx) {
                             requireActivity().finish()

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -37,6 +37,7 @@ import kotlin.math.absoluteValue
 class ListFragmentApps : Fragment(), UIObject {
     private lateinit var binding: ListAppsBinding
     private lateinit var appsRecyclerAdapter: AppsRecyclerAdapter
+    private var dismissTouchListener: RecyclerView.OnItemTouchListener? = null
 
 
     private var sharedPreferencesListener =
@@ -151,12 +152,14 @@ class ListFragmentApps : Fragment(), UIObject {
                 }
             }
         )
-        binding.listAppsRview.addOnItemTouchListener(object : RecyclerView.SimpleOnItemTouchListener() {
+        dismissTouchListener?.let { binding.listAppsRview.removeOnItemTouchListener(it) }
+        dismissTouchListener = object : RecyclerView.SimpleOnItemTouchListener() {
             override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
                 dismissDetector.onTouchEvent(e)
                 return false // never consume — RecyclerView handles scrolling normally
             }
-        })
+        }
+        binding.listAppsRview.addOnItemTouchListener(dismissTouchListener!!)
 
         binding.listAppsSearchview.setOnQueryTextListener(object :
             androidx.appcompat.widget.SearchView.OnQueryTextListener {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -5,10 +5,14 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.GestureDetector
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.GestureDetectorCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -120,6 +124,39 @@ class ListFragmentApps : Fragment(), UIObject {
                 })
             }
         }
+
+        // Dismiss the app list by swiping down when already at the scroll boundary.
+        // Standard layout: boundary is the top (canScrollVertically(-1) == false).
+        // Reversed layout: boundary is the visual bottom (canScrollVertically(1) == false).
+        val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
+        val dismissDetector = GestureDetectorCompat(
+            requireContext(),
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onFling(
+                    e1: MotionEvent?,
+                    e2: MotionEvent,
+                    velocityX: Float,
+                    velocityY: Float
+                ): Boolean {
+                    val atBoundary = if (LauncherPreferences.list().reverseLayout())
+                        !binding.listAppsRview.canScrollVertically(1)
+                    else
+                        !binding.listAppsRview.canScrollVertically(-1)
+
+                    if (atBoundary && velocityY > minFlingVelocity) {
+                        requireActivity().finish()
+                        return true
+                    }
+                    return false
+                }
+            }
+        )
+        binding.listAppsRview.addOnItemTouchListener(object : RecyclerView.SimpleOnItemTouchListener() {
+            override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+                dismissDetector.onTouchEvent(e)
+                return false // never consume — RecyclerView handles scrolling normally
+            }
+        })
 
         binding.listAppsSearchview.setOnQueryTextListener(object :
             androidx.appcompat.widget.SearchView.OnQueryTextListener {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -125,9 +125,10 @@ class ListFragmentApps : Fragment(), UIObject {
             }
         }
 
-        // Dismiss the app list by swiping down when already at the scroll boundary.
-        // Standard layout: boundary is the top (canScrollVertically(-1) == false).
-        // Reversed layout: boundary is the visual bottom (canScrollVertically(1) == false).
+        // Dismiss the app list by swiping down when already at the top scroll boundary.
+        // canScrollVertically(-1) == false means the list cannot scroll further upward,
+        // i.e. the top of the content is visible. This is the dismiss boundary for both
+        // standard and reversed layouts.
         val minFlingVelocity = ViewConfiguration.get(requireContext()).scaledMinimumFlingVelocity
         val dismissThresholdPx = (40 * resources.displayMetrics.density).toInt()
         var overscrollDistance = 0f
@@ -145,10 +146,7 @@ class ListFragmentApps : Fragment(), UIObject {
                     distanceX: Float,
                     distanceY: Float
                 ): Boolean {
-                    val atBoundary = if (LauncherPreferences.list().reverseLayout())
-                        !binding.listAppsRview.canScrollVertically(1)
-                    else
-                        !binding.listAppsRview.canScrollVertically(-1)
+                    val atBoundary = !binding.listAppsRview.canScrollVertically(-1)
 
                     if (atBoundary && distanceY < 0) {
                         // distanceY < 0 means finger is moving down
@@ -169,10 +167,7 @@ class ListFragmentApps : Fragment(), UIObject {
                     velocityX: Float,
                     velocityY: Float
                 ): Boolean {
-                    val atBoundary = if (LauncherPreferences.list().reverseLayout())
-                        !binding.listAppsRview.canScrollVertically(1)
-                    else
-                        !binding.listAppsRview.canScrollVertically(-1)
+                    val atBoundary = !binding.listAppsRview.canScrollVertically(-1)
 
                     if (atBoundary && velocityY > minFlingVelocity) {
                         requireActivity().finish()


### PR DESCRIPTION
To close #174

I've stayed up way too long looking at this problem. Too tired to pretty this up with markdown at the moment. Here's my work in action: https://youtube.com/shorts/ExDc7Z_frJo?feature=share

Closes the app menu by swipe_dn from 1) the menu, 2) the All Apps title, or 3) the "x". I left the settings icon alone so swiping down on it should not close the app list, as I figured that could be a frustration point for users trying to open settings but accidentally put a little swipe_dn motion on their tap.

Doesn't close the list if scrolling a bit and then back to/past the start in the same gesture. Doesn't close the list if you scroll with great momentum (fling). I swear there was one other edge case I caught and handled but I didn't write it down.