### PR TITLE
feat: add custom font size setting for clock widget

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -67,6 +67,7 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "flip_date_time", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "localized", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "show_seconds", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "font_size", type = int.class, defaultValue = "30")
                 }),
                 @PreferenceGroup(name = "display", prefix = "settings_display_", suffix = "_key", value = {
                         @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -25,7 +25,8 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
 
     private var sharedPreferencesListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, prefKey ->
-            if (prefKey?.startsWith("clock.") == true ||
+            if ((prefKey?.startsWith("clock.") == true &&
+                 prefKey != LauncherPreferences.clock().keys().fontSize()) ||
                 prefKey?.startsWith("display.") == true
             ) {
                 recreate()

--- a/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
@@ -1,8 +1,10 @@
 package de.jrpie.android.launcher.ui.widgets
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.text.format.DateFormat
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
@@ -28,9 +30,28 @@ class ClockView(
     val binding: WidgetClockBinding =
         WidgetClockBinding.inflate(LayoutInflater.from(context), this, true)
 
+    private val fontSizeListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == LauncherPreferences.clock().keys().fontSize()) {
+                initClock()
+            }
+        }
+
     init {
         initClock()
         setOnClicks()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        LauncherPreferences.getSharedPreferences()
+            .registerOnSharedPreferenceChangeListener(fontSizeListener)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        LauncherPreferences.getSharedPreferences()
+            .unregisterOnSharedPreferenceChangeListener(fontSizeListener)
     }
 
 
@@ -78,6 +99,10 @@ class ClockView(
 
         binding.clockUpperView.setTextColor(LauncherPreferences.clock().color())
         binding.clockLowerView.setTextColor(LauncherPreferences.clock().color())
+
+        val fontSize = LauncherPreferences.clock().fontSize().toFloat()
+        binding.clockUpperView.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize)
+        binding.clockLowerView.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize * 0.6f)
 
         binding.clockLowerView.format24Hour = lowerFormat
         binding.clockUpperView.format24Hour = upperFormat

--- a/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/widgets/ClockView.kt
@@ -1,8 +1,10 @@
 package de.jrpie.android.launcher.ui.widgets
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.text.format.DateFormat
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
@@ -28,9 +30,28 @@ class ClockView(
     val binding: WidgetClockBinding =
         WidgetClockBinding.inflate(LayoutInflater.from(context), this, true)
 
+    private val fontSizeListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == LauncherPreferences.clock().keys().fontSize()) {
+                initClock()
+            }
+        }
+
     init {
         initClock()
         setOnClicks()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        LauncherPreferences.getSharedPreferences()
+            .registerOnSharedPreferenceChangeListener(fontSizeListener)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        LauncherPreferences.getSharedPreferences()
+            .unregisterOnSharedPreferenceChangeListener(fontSizeListener)
     }
 
 
@@ -83,6 +104,10 @@ class ClockView(
             binding.clockUpperView.setTypeface(it)
             binding.clockLowerView.setTypeface(it)
         }
+
+        val fontSize = LauncherPreferences.clock().fontSize().toFloat()
+        binding.clockUpperView.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize)
+        binding.clockLowerView.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize * 0.6f)
 
         binding.clockLowerView.format24Hour = lowerFormat
         binding.clockUpperView.format24Hour = upperFormat

--- a/app/src/main/res/layout/widget_clock.xml
+++ b/app/src/main/res/layout/widget_clock.xml
@@ -12,20 +12,22 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="start|center_vertical"
-        android:textSize="30sp"
+
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="2024-12-24" />
+        tools:text="2024-12-24"
+        tools:textSize="30sp" />
 
     <TextClock
         android:id="@+id/clock_lower_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="start|center_vertical"
-        android:textSize="18sp"
+
         tools:text="18:00:00"
+        tools:textSize="18sp"
         app:layout_constraintTop_toBottomOf="@+id/clock_upper_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -150,6 +150,7 @@
     <string name="settings_clock_date_visible_key" translatable="false">clock.date_visible</string>
     <string name="settings_clock_localized_key" translatable="false">clock.date_localized</string>
     <string name="settings_clock_flip_date_time_key" translatable="false">clock.date_time_flip</string>
+    <string name="settings_clock_font_size_key" translatable="false">clock.font_size</string>
 
 
     <!--

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
 
     <string name="settings_launcher_section_date_time"><![CDATA[Date & time]]></string>
     <string name="settings_clock_color">Color</string>
+    <string name="settings_clock_font_size">Font size</string>
     <string name="settings_clock_time_visible">Show time</string>
     <string name="settings_clock_date_visible">Show date</string>
     <string name="settings_clock_localized">Use localized date format</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,6 +85,13 @@
             android:key="@string/settings_clock_flip_date_time_key"
             android:defaultValue="false"
             android:title="@string/settings_clock_flip_date_time" />
+        <SeekBarPreference
+            android:key="@string/settings_clock_font_size_key"
+            android:defaultValue="30"
+            app:min="12"
+            android:max="64"
+            android:title="@string/settings_clock_font_size"
+            app:showSeekBarValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## What's up?

I added a font size slider for the clock widget as requested in Discord. It sits at the bottom of **Settings > Date & Time**. The slider goes from 12–64sp and defaults to 30sp like it does now. `12sp` seems a practical minimum from my testing for legibility, fits Material Design 3's smallest [recommended text size](https://developer.android.com/develop/ui/compose/designsystems/material3#typography) and `64sp` hits the upper limit of MD3's largest recommended text size. Should close #12 as the last item to check off the list. 

## How it works

The upper text (date or time, depending on the flip setting) renders at the selected size. The lower element is scaled to **60%** of that value, preserving the same ratio as the current hardcoded sizes.

## Files changed

- **`LauncherPreferences$Config.java`**: new `font_size` _int_ preference (`default: 30`) in the `clock` group
- **`ClockView.kt`**: reads the preference in `initClock()` and applies [`setTextSize(COMPLEX_UNIT_SP, ...)`](https://developer.android.com/reference/android/widget/TextView#setTextSize(int,%20float)) to both views
- **`widget_clock.xml`**: removes hardcoded `android:textSize` attrs (which would override the programmatic value); adds `tools:textSize` for layout previews in Android Studio
- **`preferences.xml`**: added `SeekBarPreference` with `app:showSeekBarValue="true"` and `app:min="12"` (note: `min` requires the `app:` namespace in AndroidX because `android:min` is silently ignored by `SeekBarPreference`, to make it even better, `app:max` isn't a thing, but `android:max` is. The API is stinkin dumb. It took me so long to figure this out lol)
- **`strings.xml` / `donottranslate.xml`**: strings are abstracted here like all the other strings we use

## What it looks like

### Changing slider values

https://youtube.com/shorts/YEZLpuXUr78

### Changing other date / time settings with a custom slider value set

https://youtube.com/shorts/mZ6pFsaIYEI