### PR TITLE
Launch web search in its own task so it persists across app switching

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ListFragmentApps.kt
@@ -129,6 +129,7 @@ class ListFragmentApps : Fragment(), UIObject {
 
                 if (LauncherPreferences.functionality().searchWeb()) {
                     val i = Intent(Intent.ACTION_WEB_SEARCH).putExtra("query", query)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     try {
                         activity?.startActivity(i)
                     } catch (_: ActivityNotFoundException) {


### PR DESCRIPTION
Currently, submitting a web search from the app list starts the search activity inside the launcher's own task. Since the launcher task is the home task, Android hides it from recents, so the search vanishes the moment you swipe away or enter the app switcher.

The fix adds `Intent.FLAG_ACTIVITY_NEW_TASK` to the search intent, so the search app opens in its own task. It now shows up in the app switcher and you can leave and return to it like any normal app.