### PR TITLE
fix edge width overlay flash on fresh install; show slider value

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/ui/settings/GestureAreaIndicatorOverlayView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/settings/GestureAreaIndicatorOverlayView.kt
@@ -27,9 +27,18 @@ class GestureAreaIndicatorOverlayView(context: Context?, attrs: AttributeSet?) :
         visibility = INVISIBLE
     }
 
+    private var edgeWidth = LauncherPreferences.enabled_gestures().edgeSwipeEdgeWidth()
+
     private var sharedPreferencesListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, prefKey ->
             if (prefKey == LauncherPreferences.enabled_gestures().keys().edgeSwipeEdgeWidth()) {
+                // On a fresh install, SeekBarPreference persists its default value when the
+                // settings screen is first opened; only show the overlay on an actual change.
+                val newEdgeWidth = LauncherPreferences.enabled_gestures().edgeSwipeEdgeWidth()
+                if (newEdgeWidth == edgeWidth) {
+                    return@OnSharedPreferenceChangeListener
+                }
+                edgeWidth = newEdgeWidth
 
                 this.removeCallbacks(hideTask)
                 visibility = VISIBLE

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -139,8 +139,10 @@
             <SeekBarPreference
                 android:key="@string/settings_enabled_gestures_edge_swipe_edge_width_key"
                 android:defaultValue="15"
+                app:min="5"
                 android:max="33"
-                android:title="@string/settings_enabled_gestures_edge_swipe_edge_width" />
+                android:title="@string/settings_enabled_gestures_edge_swipe_edge_width"
+                app:showSeekBarValue="true" />
         </PreferenceCategory>
         <SwitchPreference
             android:key="@string/settings_enabled_gestures_diagonal_swipe_key"


### PR DESCRIPTION
## What's up?

Two small edge-width enhancements:

**Fix the overlay flashing on fresh install (fixes #280):** on a fresh install, `SeekBarPreference` persists its default value the first time the settings screen is opened (`onSetInitialValue` → `setValueInternal` → `persistInt`). That first write fired the shared preference listener in `GestureAreaIndicatorOverlayView`, flashing the overlay for 3 seconds. The listener now caches the last known value and only shows the overlay when the value actually changed. The `requestLayout()` warnings in the issue's logcat turned out to be unrelated seekbar-label noise.

**Numeric value on the slider:** added `app:showSeekBarValue="true"` (same as the clock font size slider from #299) and a minimum of 5 via `app:min` (`android:min` is silently ignored by `SeekBarPreference`).