### PR TITLE
Add an opt-in Minimalist Mode

### DIFF
--- a/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
@@ -444,6 +444,16 @@ enum class Gesture(
 
     operator fun invoke(context: Context) {
         Log.i("Launcher", "Detected gesture: $this")
+
+        if (LauncherPreferences.minimalist().enabled()) {
+            // In minimalist mode every gesture is disabled, except long click,
+            // which always opens µLauncher settings - regardless of what is bound to it.
+            if (this == LONG_CLICK) {
+                Action.launch(LauncherAction.SETTINGS, context, this)
+            }
+            return
+        }
+
         val action = Action.forGesture(this)
         Action.launch(action, context, this)
     }

--- a/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/actions/Gesture.kt
@@ -445,9 +445,12 @@ enum class Gesture(
     operator fun invoke(context: Context) {
         Log.i("Launcher", "Detected gesture: $this")
 
-        if (LauncherPreferences.minimalist().enabled()) {
+        if (LauncherPreferences.minimalist().enabled() &&
+            !LauncherPreferences.minimalist().allowGestures()
+        ) {
             // In minimalist mode every gesture is disabled, except long click,
             // which always opens µLauncher settings - regardless of what is bound to it.
+            // (Unless "allow gestures" is on, in which case gestures behave normally.)
             if (this == LONG_CLICK) {
                 Action.launch(LauncherAction.SETTINGS, context, this)
             }

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -96,6 +96,7 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 }),
                 @PreferenceGroup(name = "minimalist", prefix = "settings_minimalist_", suffix = "_key", value = {
                         @Preference(name = "enabled", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "allow_gestures", type = boolean.class, defaultValue = "false"),
                         @Preference(name = "apps", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class),
                 }),
         })

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -94,6 +94,10 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "widgets", type = Set.class, serializer = SetWidgetSerializer.class),
                         @Preference(name = "custom_panels", type = Set.class, serializer = SetWidgetPanelSerializer.class)
                 }),
+                @PreferenceGroup(name = "minimalist", prefix = "settings_minimalist_", suffix = "_key", value = {
+                        @Preference(name = "enabled", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "apps", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class),
+                }),
         })
 public final class LauncherPreferences$Config {
 }

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -63,7 +63,7 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
 
     private fun updateMinimalistMode() {
         val enabled = LauncherPreferences.minimalist().enabled()
-        binding.homeMinimalistList.visibility = if (enabled) View.VISIBLE else View.GONE
+        binding.homeMinimalistContainer.visibility = if (enabled) View.VISIBLE else View.GONE
         binding.homeWidgetContainer.visibility = if (enabled) View.GONE else View.VISIBLE
         if (enabled) {
             minimalistAdapter.updateAppsList()
@@ -137,6 +137,7 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
     override fun onDestroy() {
         LauncherPreferences.getSharedPreferences()
             .unregisterOnSharedPreferenceChangeListener(sharedPreferencesListener)
+        minimalistAdapter.destroy()
         super.onDestroy()
     }
 

--- a/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/HomeActivity.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Bundle
 import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
 import de.jrpie.android.launcher.Application
 import de.jrpie.android.launcher.actions.Action
 import de.jrpie.android.launcher.actions.Gesture
@@ -11,6 +12,7 @@ import de.jrpie.android.launcher.actions.LauncherAction
 import de.jrpie.android.launcher.databinding.ActivityHomeBinding
 import de.jrpie.android.launcher.openTutorial
 import de.jrpie.android.launcher.preferences.LauncherPreferences
+import de.jrpie.android.launcher.ui.minimalist.MinimalistHomeAdapter
 import de.jrpie.android.launcher.ui.util.LauncherGestureActivity
 
 
@@ -22,6 +24,7 @@ import de.jrpie.android.launcher.ui.util.LauncherGestureActivity
 class HomeActivity : UIObject, LauncherGestureActivity() {
 
     private lateinit var binding: ActivityHomeBinding
+    private lateinit var minimalistAdapter: MinimalistHomeAdapter
 
     private var sharedPreferencesListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, prefKey ->
@@ -34,6 +37,8 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
                     this@HomeActivity,
                     LauncherPreferences.widgets().widgets()
                 )
+            } else if (prefKey?.startsWith("minimalist.") == true) {
+                updateMinimalistMode()
             }
 
         }
@@ -47,8 +52,21 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
 
         setContentView(binding.root)
 
+        minimalistAdapter = MinimalistHomeAdapter(this)
+        binding.homeMinimalistList.layoutManager = LinearLayoutManager(this)
+        binding.homeMinimalistList.adapter = minimalistAdapter
+
         binding.buttonFallbackSettings.setOnClickListener {
             LauncherAction.SETTINGS.invoke(this)
+        }
+    }
+
+    private fun updateMinimalistMode() {
+        val enabled = LauncherPreferences.minimalist().enabled()
+        binding.homeMinimalistList.visibility = if (enabled) View.VISIBLE else View.GONE
+        binding.homeWidgetContainer.visibility = if (enabled) View.GONE else View.VISIBLE
+        if (enabled) {
+            minimalistAdapter.updateAppsList()
         }
     }
 
@@ -105,6 +123,7 @@ class HomeActivity : UIObject, LauncherGestureActivity() {
     override fun onResume() {
         super.onResume()
         updateSettingsFallbackButtonVisibility()
+        updateMinimalistMode()
 
         binding.homeWidgetContainer.updateWidgets(
             this@HomeActivity,

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/AppsRecyclerAdapter.kt
@@ -144,6 +144,10 @@ class AppsRecyclerAdapter(
             popup.menu.findItem(R.id.app_menu_favorite).setTitle(R.string.list_app_favorite_remove)
         }
 
+        if (LauncherPreferences.minimalist().apps()?.contains(appInfo.getRawInfo()) == true) {
+            popup.menu.findItem(R.id.app_menu_minimalist).setTitle(R.string.list_app_minimalist_remove)
+        }
+
 
         popup.setOnMenuItemClickListener {
             when (it.itemId) {
@@ -161,6 +165,10 @@ class AppsRecyclerAdapter(
 
                 R.id.app_menu_hidden -> {
                     appInfo.getRawInfo().toggleHidden(root); true
+                }
+
+                R.id.app_menu_minimalist -> {
+                    appInfo.getRawInfo().toggleMinimalistApp(); true
                 }
 
                 R.id.app_menu_rename -> {

--- a/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ContextMenuActions.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/list/apps/ContextMenuActions.kt
@@ -70,6 +70,21 @@ fun AbstractAppInfo.toggleFavorite() {
     LauncherPreferences.apps().favorites(favorites)
 }
 
+fun AbstractAppInfo.toggleMinimalistApp() {
+    val apps: MutableSet<AbstractAppInfo> =
+        LauncherPreferences.minimalist().apps() ?: mutableSetOf()
+
+    if (apps.contains(this)) {
+        apps.remove(this)
+        Log.i(LOG_TAG, "Removing $this from minimalist app list.")
+    } else {
+        Log.i(LOG_TAG, "Adding $this to minimalist app list.")
+        apps.add(this)
+    }
+
+    LauncherPreferences.minimalist().apps(apps)
+}
+
 /**
  * @param view: used to show a snackbar letting the user undo the action
  */

--- a/app/src/main/java/de/jrpie/android/launcher/ui/minimalist/MinimalistHomeAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/minimalist/MinimalistHomeAdapter.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import de.jrpie.android.launcher.Application
 import de.jrpie.android.launcher.R
@@ -25,11 +26,19 @@ class MinimalistHomeAdapter(private val activity: Activity) :
     private val apps = (activity.applicationContext as Application).apps
     private val appsListDisplayed: MutableList<AbstractDetailedAppInfo> = mutableListOf()
 
+    // HomeActivity is a plain Activity (not a LifecycleOwner), so this can't use the usual
+    // apps.observe(lifecycleOwner, ...). Installed apps load asynchronously (Application.loadApps),
+    // so without this, a cold start can leave the list empty forever if apps.value was still
+    // null when the adapter was first built. destroy() must be called from onDestroy().
+    private val appsObserver = Observer<List<AbstractDetailedAppInfo>> { updateAppsList() }
+
     init {
-        // HomeActivity is a plain Activity (not lifecycle-aware), so this list is
-        // refreshed explicitly by the caller (see HomeActivity.updateMinimalistMode())
-        // rather than via a LiveData observer.
         updateAppsList()
+        apps.observeForever(appsObserver)
+    }
+
+    fun destroy() {
+        apps.removeObserver(appsObserver)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),

--- a/app/src/main/java/de/jrpie/android/launcher/ui/minimalist/MinimalistHomeAdapter.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/minimalist/MinimalistHomeAdapter.kt
@@ -1,0 +1,73 @@
+package de.jrpie.android.launcher.ui.minimalist
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.graphics.Rect
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import de.jrpie.android.launcher.Application
+import de.jrpie.android.launcher.R
+import de.jrpie.android.launcher.apps.AbstractDetailedAppInfo
+import de.jrpie.android.launcher.preferences.LauncherPreferences
+
+/**
+ * A minimal [RecyclerView.Adapter] showing a plain text list of the apps chosen for
+ * minimalist mode ([LauncherPreferences.minimalist] `apps`). Tapping a row launches the
+ * app directly, bypassing the gesture system entirely.
+ */
+@SuppressLint("NotifyDataSetChanged")
+class MinimalistHomeAdapter(private val activity: Activity) :
+    RecyclerView.Adapter<MinimalistHomeAdapter.ViewHolder>() {
+
+    private val apps = (activity.applicationContext as Application).apps
+    private val appsListDisplayed: MutableList<AbstractDetailedAppInfo> = mutableListOf()
+
+    init {
+        // HomeActivity is a plain Activity (not lifecycle-aware), so this list is
+        // refreshed explicitly by the caller (see HomeActivity.updateMinimalistMode())
+        // rather than via a LiveData observer.
+        updateAppsList()
+    }
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
+        View.OnClickListener {
+        var textView: TextView = itemView.findViewById(R.id.list_apps_row_name)
+
+        override fun onClick(v: View) {
+            val rect = Rect()
+            v.getGlobalVisibleRect(rect)
+            appsListDisplayed.getOrNull(bindingAdapterPosition)?.getAction()?.invoke(activity, rect)
+        }
+
+        init {
+            itemView.setOnClickListener(this)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.list_apps_row_variant_text, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.textView.text = appsListDisplayed[position].getCustomLabel(activity)
+    }
+
+    override fun getItemCount(): Int = appsListDisplayed.size
+
+    fun updateAppsList() {
+        val selection = LauncherPreferences.minimalist().apps() ?: emptySet()
+        appsListDisplayed.clear()
+        apps.value?.let { all ->
+            appsListDisplayed.addAll(
+                all.filter { selection.contains(it.getRawInfo()) }
+                    .sortedBy { it.getCustomLabel(activity).lowercase() }
+            )
+        }
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/settings/launcher/SettingsFragmentLauncher.kt
@@ -107,6 +107,14 @@ class SettingsFragmentLauncher : PreferenceFragmentCompat() {
             true
         }
 
+        val minimalistApps = findPreference<androidx.preference.Preference>(
+            LauncherPreferences.minimalist().keys().apps()
+        )
+        minimalistApps?.setOnPreferenceClickListener {
+            openAppsList(requireContext())
+            true
+        }
+
         val lockMethod = findPreference<androidx.preference.Preference>(
             LauncherPreferences.actions().keys().lockMethod()
         )

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -15,17 +15,31 @@
         android:layout_height="match_parent" />
 
     <!-- shown instead of home_widget_container while minimalist mode is enabled -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/home_minimalist_list"
+    <LinearLayout
+        android:id="@+id/home_minimalist_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible"
-        tools:listitem="@layout/list_apps_row_variant_text"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <de.jrpie.android.launcher.ui.widgets.ClockView
+            android:id="@+id/home_minimalist_clock"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/home_minimalist_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            tools:listitem="@layout/list_apps_row_variant_text" />
+
+    </LinearLayout>
 
     <!-- only shown when µLauncher settings can't be reached by a gesture -->
     <ImageView

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -14,6 +14,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <!-- shown instead of home_widget_container while minimalist mode is enabled -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/home_minimalist_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:listitem="@layout/list_apps_row_variant_text"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- only shown when µLauncher settings can't be reached by a gesture -->
     <ImageView
         android:id="@+id/button_fallback_settings"

--- a/app/src/main/res/menu/menu_app.xml
+++ b/app/src/main/res/menu/menu_app.xml
@@ -10,6 +10,9 @@
         android:id="@+id/app_menu_hidden"
         android:title="@string/list_app_hidden_add" />
     <item
+        android:id="@+id/app_menu_minimalist"
+        android:title="@string/list_app_minimalist_add" />
+    <item
         android:id="@+id/app_menu_rename"
         android:title="@string/list_app_rename" />
     <item

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -22,6 +22,8 @@
     <string name="settings_list_app_name_format_key" translatable="false">list.app_name_format</string>
     <string name="settings_list_reverse_layout_key" translatable="false">list.reverse_layout</string>
     <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
+    <string name="settings_minimalist_enabled_key" translatable="false">minimalist.enabled</string>
+    <string name="settings_minimalist_apps_key" translatable="false">minimalist.apps</string>
 
     <!-- values of de.jrpie.android.launcher.preferences.list.ListLayout -->
     <string-array name="settings_list_layout_values" translatable="false">

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -23,6 +23,7 @@
     <string name="settings_list_reverse_layout_key" translatable="false">list.reverse_layout</string>
     <string name="settings_general_choose_home_screen_key" translatable="false">general.select_launcher</string>
     <string name="settings_minimalist_enabled_key" translatable="false">minimalist.enabled</string>
+    <string name="settings_minimalist_allow_gestures_key" translatable="false">minimalist.allow_gestures</string>
     <string name="settings_minimalist_apps_key" translatable="false">minimalist.apps</string>
 
     <!-- values of de.jrpie.android.launcher.preferences.list.ListLayout -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="list_app_favorite_remove">Remove from favorites</string>
     <string name="list_app_hidden_add">Hide</string>
     <string name="list_app_hidden_remove">Show</string>
+    <string name="list_app_minimalist_add">Add to minimalist list</string>
+    <string name="list_app_minimalist_remove">Remove from minimalist list</string>
     <string name="list_app_rename">Rename</string>
 
     <string name="list_apps_search_hint">Search</string>
@@ -449,6 +451,11 @@
     <string name="list_other_open_widget_panel">Open Widget Panel</string>
     <string name="alert_widget_panel_not_found">This widget panel no longer exists.</string>
     <string name="settings_launcher_section_widgets">Widgets</string>
+    <string name="settings_launcher_section_minimalist">Minimalist Mode</string>
+    <string name="settings_minimalist_enabled">Enable minimalist mode</string>
+    <string name="settings_minimalist_enabled_summary">Replace the home screen with a plain list of chosen apps. While enabled, every gesture is disabled except long click, which always opens these settings.</string>
+    <string name="settings_minimalist_apps">Manage home screen apps</string>
+    <string name="settings_minimalist_apps_summary">Choose which apps show up on the minimalist home screen (long-press an app in the list)</string>
     <string name="notification_crash_title">μLauncher crashed</string>
     <string name="notification_crash_explanation">Sorry! Click for more information.</string>
     <string name="crash_info"><![CDATA[

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,7 +453,9 @@
     <string name="settings_launcher_section_widgets">Widgets</string>
     <string name="settings_launcher_section_minimalist">Minimalist Mode</string>
     <string name="settings_minimalist_enabled">Enable minimalist mode</string>
-    <string name="settings_minimalist_enabled_summary">Replace the home screen with a plain list of chosen apps. While enabled, every gesture is disabled except long click, which always opens these settings.</string>
+    <string name="settings_minimalist_enabled_summary">Replace the home screen with a plain list of chosen apps. By default every gesture is disabled except long click, which always opens these settings; see \"Allow gestures\" below to change that.</string>
+    <string name="settings_minimalist_allow_gestures">Allow gestures</string>
+    <string name="settings_minimalist_allow_gestures_summary">Let gestures work normally while minimalist mode is on, instead of disabling them. Long click will no longer be forced to open settings.</string>
     <string name="settings_minimalist_apps">Manage home screen apps</string>
     <string name="settings_minimalist_apps_summary">Choose which apps show up on the minimalist home screen (long-press an app in the list)</string>
     <string name="notification_crash_title">μLauncher crashed</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -229,4 +229,18 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/settings_launcher_section_minimalist"
+        app:allowDividerAbove="false">
+        <SwitchPreference
+            android:key="@string/settings_minimalist_enabled_key"
+            android:defaultValue="false"
+            android:title="@string/settings_minimalist_enabled"
+            android:summary="@string/settings_minimalist_enabled_summary" />
+        <Preference
+            android:key="@string/settings_minimalist_apps_key"
+            android:title="@string/settings_minimalist_apps"
+            android:summary="@string/settings_minimalist_apps_summary" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -237,6 +237,11 @@
             android:defaultValue="false"
             android:title="@string/settings_minimalist_enabled"
             android:summary="@string/settings_minimalist_enabled_summary" />
+        <SwitchPreference
+            android:key="@string/settings_minimalist_allow_gestures_key"
+            android:defaultValue="false"
+            android:title="@string/settings_minimalist_allow_gestures"
+            android:summary="@string/settings_minimalist_allow_gestures_summary" />
         <Preference
             android:key="@string/settings_minimalist_apps_key"
             android:title="@string/settings_minimalist_apps"


### PR DESCRIPTION
# Add an opt-in "Minimalist Mode"

## Summary

Adds an opt-in **Minimalist Mode**: a stripped-down home screen showing a plain text list
of a user-chosen set of apps (independent of the existing favorites list), inspired by
Olauncher's minimal list-based home screen. Implemented from scratch in Kotlin, reusing
existing patterns/components rather than adding new ones where possible.

## Why

Some users want a distraction-free home screen that's just a short list of essential apps,
with everything else (the app drawer, other gestures) put behind a bit of friction so it's
not one swipe away. This is a common "minimalist launcher" feature (see Olauncher), which
felt like a natural fit for μLauncher's existing gesture/action system.

## What it does

- **Settings → Launcher → Minimalist Mode**: a new category with:
  - **Enable minimalist mode** — swaps the home screen's widget container for a plain
    text list of chosen apps (reuses the existing `ListLayout.TEXT` row style). The
    existing clock (date/time) stays visible above the list.
  - **Allow gestures** — off by default. When off, every gesture is disabled *except*
    long click, which always opens Settings regardless of what's actually bound to it
    (so there's always a way back in). When on, gestures behave exactly as configured
    normally — useful for people who just want the minimalist *look* without the lockdown.
  - **Manage home screen apps** — opens the existing app list/drawer, where long-press
    now has an "Add/remove from minimalist list" option, mirroring the existing
    Favorite/Hidden toggles.
- Tapping an app in the minimalist list launches it directly (via the same
  `AbstractDetailedAppInfo.getAction()` path the regular app list uses) — this is
  intentionally the *only* interaction never gated by the lockdown.

## Implementation notes

- Single choke point: the lockdown/allow-gestures logic lives entirely in
  `Gesture.operator fun invoke()`, so it automatically covers every existing (and future)
  gesture without touching each `LauncherAction` individually.
- New preference group `minimalist` (`enabled`, `allow_gestures`, `apps`) follows the
  existing `@PreferenceGroup`/`@Preference` annotation pattern; `apps` reuses the existing
  `SetAbstractAppInfoPreferenceSerializer` used by `favorites`/`hidden`.
- The minimalist app-list toggle in the drawer's long-press menu mirrors the existing
  favorite/hidden toggle pattern exactly (`ContextMenuActions.kt`, `menu_app.xml`,
  `AppsRecyclerAdapter.showOptionsPopup`).
- The home screen's clock is the existing `ClockView`, reused as-is (it already supports
  being dropped into a layout standalone via its 2-arg constructor).

## Testing

- `./gradlew build` passes locally.
- Manually verified on an emulator (Android 14):
  - Enabling minimalist mode swaps to the list view; disabling restores the normal
    widget-based home screen with no residue.
  - Managing the app list via long-press in the drawer persists correctly.
  - Tapping a listed app launches it with no gate.
  - With "Allow gestures" off (default): all other gestures are no-ops; long click always
    opens Settings regardless of its configured binding.
  - With "Allow gestures" on: gestures behave normally (e.g. swipe up still opens the
    drawer) while the list-view home screen stays active.
  - Clock/date remains visible and live-updating on the minimalist home screen.
  - Fixed a cold-start race where the app list could render empty if the installed-apps
    list hadn't finished loading yet.

## Notes for review

This is a fairly sized feature, so I'm happy to split it up, adjust the UX, or rework
naming/placement if you'd prefer a different approach — opening this as a starting point
for discussion rather than assuming it'll land as-is.
