### PR TITLE
Add settings backup/restore (export/import to JSON), #79

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,8 @@ dependencies {
     implementation(libs.jonahbauer.android.preference.annotations)
     annotationProcessor(libs.jonahbauer.android.preference.annotations)
     testImplementation(libs.junit)
+    // the org.json classes in the android.jar unit test stubs throw; use the real implementation
+    testImplementation(libs.json)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.test.ext.junit)
 }

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/Backup.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/Backup.kt
@@ -1,0 +1,163 @@
+package de.jrpie.android.launcher.preferences
+
+import android.content.Context
+import android.os.Process
+import android.os.UserManager
+import android.util.Log
+import de.jrpie.android.launcher.actions.Action
+import de.jrpie.android.launcher.actions.Gesture
+import de.jrpie.android.launcher.apps.getPrivateSpaceUser
+import kotlinx.serialization.json.Json
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Serialization of all settings (preferences and gesture bindings) to and from JSON,
+ * used for settings backup (see SettingsFragmentMeta).
+ *
+ * The backup contains:
+ *  - all preferences annotated with `export = true` (via the generated
+ *    [LauncherPreferences.exportPreferences] and [LauncherPreferences.importPreferences]),
+ *    keyed by their preference key,
+ *  - the [Action] bound to each [Gesture], keyed by the gesture id,
+ *  - the [PREFERENCE_VERSION] the backup was created with, keyed by [BACKUP_VERSION_KEY],
+ *  - a map of user ids to profile types (main / work profile / private space), keyed by
+ *    [BACKUP_USERS_KEY], so that user ids referenced by the backup can be matched to the
+ *    corresponding profiles when importing on another device.
+ */
+
+const val BACKUP_VERSION_KEY = "_version"
+const val BACKUP_USERS_KEY = "_users"
+private const val PROFILE_TYPE_MAIN = "MAIN"
+private const val PROFILE_TYPE_WORK = "WORK"
+private const val PROFILE_TYPE_PRIVATE = "PRIVATE"
+private const val TAG = "Launcher - Backup"
+
+class BackupVersionException(message: String) : Exception(message)
+
+fun exportSettings(context: Context): JSONObject {
+    val json = LauncherPreferences.exportPreferences()
+    json.put(BACKUP_VERSION_KEY, PREFERENCE_VERSION)
+
+    val users = JSONObject()
+    getUserProfileTypes(context).forEach { (id, type) -> users.put(id.toString(), type) }
+    json.put(BACKUP_USERS_KEY, users)
+
+    Gesture.entries.forEach { gesture ->
+        Action.forGesture(gesture)?.let { action ->
+            json.put(gesture.id, JSONObject(Json.encodeToString<Action>(action)))
+        }
+    }
+    return json
+}
+
+fun importSettings(context: Context, json: JSONObject) {
+    val version = json.optInt(BACKUP_VERSION_KEY, UNKNOWN_PREFERENCE_VERSION)
+    if (version > PREFERENCE_VERSION) {
+        throw BackupVersionException(
+            "Backup was created by a newer version of the app (version $version > $PREFERENCE_VERSION)."
+        )
+    }
+    if (version < PREFERENCE_VERSION) {
+        migrateBackupToNewVersion(json, version)
+    }
+
+    remapUserIds(context, json)
+
+    LauncherPreferences.importPreferences(json)
+
+    Gesture.entries.forEach { gesture ->
+        json.optJSONObject(gesture.id)?.let {
+            Action.setActionForGesture(gesture, Json.decodeFromString<Action>(it.toString()))
+        }
+    }
+
+    // The imported preferences are in the current format and belong to a configured launcher.
+    // Without this, `started == false` (e.g. import directly after a reset) would cause
+    // `resetPreferences` to overwrite the imported settings on the next app start.
+    LauncherPreferences.internal().started(true)
+    LauncherPreferences.internal().versionCode(PREFERENCE_VERSION)
+
+    Log.i(TAG, "settings imported (version $version)")
+}
+
+/*
+ * Counterpart of `migratePreferencesToNewVersion` operating on a backup instead of
+ * the shared preferences. When bumping PREFERENCE_VERSION, add a case here as well;
+ * migrations that need to run in both places should be written against the values
+ * (not the storage) so both callers can share them.
+ *
+ * Settings backups did not exist before PREFERENCE_VERSION 101, so versions < 101
+ * cannot occur here.
+ */
+internal fun migrateBackupToNewVersion(json: JSONObject, version: Int) {
+    when (version) {
+        // Add migration cases here when PREFERENCE_VERSION is increased beyond 101.
+        else -> {
+            throw BackupVersionException("Cannot migrate backup from version $version.")
+        }
+    }
+}
+
+/**
+ * Maps the user id (`UserHandle#hashCode`) of every profile on this device to a profile type
+ * ([PROFILE_TYPE_MAIN], [PROFILE_TYPE_WORK] or [PROFILE_TYPE_PRIVATE]).
+ */
+private fun getUserProfileTypes(context: Context): Map<Int, String> {
+    val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
+    val mainUser = Process.myUserHandle()
+    val privateSpaceUser = getPrivateSpaceUser(context)
+    return userManager.userProfiles.associate { profile ->
+        profile.hashCode() to when (profile) {
+            mainUser -> PROFILE_TYPE_MAIN
+            privateSpaceUser -> PROFILE_TYPE_PRIVATE
+            else -> PROFILE_TYPE_WORK
+        }
+    }
+}
+
+/**
+ * Rewrites all `user` fields in the backup from the user ids of the device the backup
+ * was created on to the ids of this device's profiles of the same type
+ * (using the [BACKUP_USERS_KEY] map embedded in the backup).
+ * User ids without a matching profile on this device are left unchanged.
+ */
+private fun remapUserIds(context: Context, json: JSONObject) {
+    val backupUsers = json.optJSONObject(BACKUP_USERS_KEY) ?: return
+
+    val profilesByType = HashMap<String, Int>()
+    getUserProfileTypes(context).forEach { (id, type) -> profilesByType.putIfAbsent(type, id) }
+
+    val mapping = HashMap<Int, Int>()
+    backupUsers.keys().forEach { id ->
+        profilesByType[backupUsers.getString(id)]?.let { localId ->
+            mapping[id.toInt()] = localId
+        }
+    }
+    if (mapping.isEmpty()) return
+
+    remapUserIds(json, mapping)
+}
+
+internal fun remapUserIds(value: Any?, mapping: Map<Int, Int>) {
+    when (value) {
+        is JSONObject -> {
+            for (key in value.keys().asSequence().toList()) {
+                val child = value.get(key)
+                if (key == "user" && child is Int) {
+                    mapping[child]?.let { value.put(key, it) }
+                } else {
+                    remapUserIds(child, mapping)
+                }
+            }
+        }
+
+        is JSONArray -> {
+            for (i in 0 until value.length()) {
+                remapUserIds(value.get(i), mapping)
+            }
+        }
+
+        else -> {}
+    }
+}

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/LauncherPreferences$Config.java
@@ -7,9 +7,14 @@ import de.jrpie.android.launcher.R;
 import de.jrpie.android.launcher.actions.lock.LockMethod;
 import de.jrpie.android.launcher.preferences.list.AppNameFormat;
 import de.jrpie.android.launcher.preferences.list.ListLayout;
+import de.jrpie.android.launcher.preferences.serialization.MapAbstractAppInfoStringExportSerializer;
 import de.jrpie.android.launcher.preferences.serialization.MapAbstractAppInfoStringPreferenceSerializer;
+import de.jrpie.android.launcher.preferences.serialization.SetAbstractAppInfoExportSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetAbstractAppInfoPreferenceSerializer;
+import de.jrpie.android.launcher.preferences.serialization.SetPinnedShortcutInfoExportSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetPinnedShortcutInfoPreferenceSerializer;
+import de.jrpie.android.launcher.preferences.serialization.SetWidgetExportSerializer;
+import de.jrpie.android.launcher.preferences.serialization.SetWidgetPanelExportSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetWidgetPanelSerializer;
 import de.jrpie.android.launcher.preferences.serialization.SetWidgetSerializer;
 import de.jrpie.android.launcher.preferences.theme.Background;
@@ -32,18 +37,22 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                         @Preference(name = "version_code", type = int.class, defaultValue = "-1"),
                 }),
                 @PreferenceGroup(name = "apps", prefix = "settings_apps_", suffix = "_key", value = {
-                        @Preference(name = "favorites", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class),
-                        @Preference(name = "hidden", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class),
-                        @Preference(name = "pinned_shortcuts", type = Set.class, serializer = SetPinnedShortcutInfoPreferenceSerializer.class),
-                        @Preference(name = "custom_names", type = HashMap.class, serializer = MapAbstractAppInfoStringPreferenceSerializer.class),
-                        @Preference(name = "hide_bound_apps", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "hide_paused_apps", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "hide_private_space_apps", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "favorites", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class,
+                                exportSerializer = SetAbstractAppInfoExportSerializer.class, export = true),
+                        @Preference(name = "hidden", type = Set.class, serializer = SetAbstractAppInfoPreferenceSerializer.class,
+                                exportSerializer = SetAbstractAppInfoExportSerializer.class, export = true),
+                        @Preference(name = "pinned_shortcuts", type = Set.class, serializer = SetPinnedShortcutInfoPreferenceSerializer.class,
+                                exportSerializer = SetPinnedShortcutInfoExportSerializer.class, export = true),
+                        @Preference(name = "custom_names", type = HashMap.class, serializer = MapAbstractAppInfoStringPreferenceSerializer.class,
+                                exportSerializer = MapAbstractAppInfoStringExportSerializer.class, export = true),
+                        @Preference(name = "hide_bound_apps", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "hide_paused_apps", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "hide_private_space_apps", type = boolean.class, defaultValue = "false", export = true),
                 }),
                 @PreferenceGroup(name = "list", prefix = "settings_list_", suffix = "_key", value = {
-                        @Preference(name = "layout", type = ListLayout.class, defaultValue = "DEFAULT"),
-                        @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "app_name_format", type = AppNameFormat.class, defaultValue = "DEFAULT")
+                        @Preference(name = "layout", type = ListLayout.class, defaultValue = "DEFAULT", export = true),
+                        @Preference(name = "reverse_layout", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "app_name_format", type = AppNameFormat.class, defaultValue = "DEFAULT", export = true)
                 }),
                 @PreferenceGroup(name = "gestures", prefix = "settings_gesture_", suffix = "_key", value = {
                 }),
@@ -52,47 +61,49 @@ import eu.jonahbauer.android.preference.annotations.Preferences;
                 }),
                 @PreferenceGroup(name = "theme", prefix = "settings_theme_", suffix = "_key", value = {
                         @Preference(name = "wallpaper", type = void.class),
-                        @Preference(name = "color_theme", type = ColorTheme.class, defaultValue = "DEFAULT"),
-                        @Preference(name = "background", type = Background.class, defaultValue = "DIM"),
-                        @Preference(name = "font", type = Font.class, defaultValue = "HACK"),
-                        @Preference(name = "text_shadow", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "monochrome_icons", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "animations", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "color_theme", type = ColorTheme.class, defaultValue = "DEFAULT", export = true),
+                        @Preference(name = "background", type = Background.class, defaultValue = "DIM", export = true),
+                        @Preference(name = "font", type = Font.class, defaultValue = "HACK", export = true),
+                        @Preference(name = "text_shadow", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "monochrome_icons", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "animations", type = boolean.class, defaultValue = "true", export = true),
                 }),
                 @PreferenceGroup(name = "clock", prefix = "settings_clock_", suffix = "_key", value = {
-                        @Preference(name = "font", type = Font.class, defaultValue = "HACK"),
-                        @Preference(name = "color", type = int.class, defaultValue = "0xffffffff"),
-                        @Preference(name = "date_visible", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "time_visible", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "flip_date_time", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "localized", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "show_seconds", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "font_size", type = int.class, defaultValue = "30")
+                        @Preference(name = "font", type = Font.class, defaultValue = "HACK", export = true),
+                        @Preference(name = "color", type = int.class, defaultValue = "0xffffffff", export = true),
+                        @Preference(name = "date_visible", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "time_visible", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "flip_date_time", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "localized", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "show_seconds", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "font_size", type = int.class, defaultValue = "30", export = true)
                 }),
                 @PreferenceGroup(name = "display", prefix = "settings_display_", suffix = "_key", value = {
-                        @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "hide_status_bar", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "hide_navigation_bar", type = boolean.class, defaultValue = "false"),
-                        @Preference(name = "rotate_screen", type = boolean.class, defaultValue = "true"),
+                        @Preference(name = "screen_timeout_disabled", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "hide_status_bar", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "hide_navigation_bar", type = boolean.class, defaultValue = "false", export = true),
+                        @Preference(name = "rotate_screen", type = boolean.class, defaultValue = "true", export = true),
                 }),
                 @PreferenceGroup(name = "functionality", prefix = "settings_functionality_", suffix = "_key", value = {
-                        @Preference(name = "search_auto_launch", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "search_web", type = boolean.class, description = "false"),
-                        @Preference(name = "search_auto_open_keyboard", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "search_auto_close_keyboard", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "search_auto_launch", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "search_web", type = boolean.class, description = "false", export = true),
+                        @Preference(name = "search_auto_open_keyboard", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "search_auto_close_keyboard", type = boolean.class, defaultValue = "false", export = true),
                 }),
                 @PreferenceGroup(name = "enabled_gestures", prefix = "settings_enabled_gestures_", suffix = "_key", value = {
-                        @Preference(name = "double_swipe", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "edge_swipe", type = boolean.class, defaultValue = "true"),
-                        @Preference(name = "edge_swipe_edge_width", type = int.class, defaultValue = "15"),
-                        @Preference(name = "diagonal_swipe", type = boolean.class, defaultValue = "false"),
+                        @Preference(name = "double_swipe", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "edge_swipe", type = boolean.class, defaultValue = "true", export = true),
+                        @Preference(name = "edge_swipe_edge_width", type = int.class, defaultValue = "15", export = true),
+                        @Preference(name = "diagonal_swipe", type = boolean.class, defaultValue = "false", export = true),
                 }),
                 @PreferenceGroup(name = "actions", prefix = "settings_actions_", suffix = "_key", value = {
-                        @Preference(name = "lock_method", type = LockMethod.class, defaultValue = "DEVICE_ADMIN"),
+                        @Preference(name = "lock_method", type = LockMethod.class, defaultValue = "DEVICE_ADMIN", export = true),
                 }),
                 @PreferenceGroup(name = "widgets", prefix = "settings_widgets_", suffix = "_key", value = {
-                        @Preference(name = "widgets", type = Set.class, serializer = SetWidgetSerializer.class),
-                        @Preference(name = "custom_panels", type = Set.class, serializer = SetWidgetPanelSerializer.class)
+                        @Preference(name = "widgets", type = Set.class, serializer = SetWidgetSerializer.class,
+                                exportSerializer = SetWidgetExportSerializer.class, export = true),
+                        @Preference(name = "custom_panels", type = Set.class, serializer = SetWidgetPanelSerializer.class,
+                                exportSerializer = SetWidgetPanelExportSerializer.class, export = true)
                 }),
         })
 public final class LauncherPreferences$Config {

--- a/app/src/main/java/de/jrpie/android/launcher/preferences/serialization/PreferenceSerializers.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/preferences/serialization/PreferenceSerializers.kt
@@ -4,12 +4,17 @@ package de.jrpie.android.launcher.preferences.serialization
 
 import de.jrpie.android.launcher.apps.AbstractAppInfo
 import de.jrpie.android.launcher.apps.PinnedShortcutInfo
+import de.jrpie.android.launcher.widgets.AppWidget
+import de.jrpie.android.launcher.widgets.BrokenWidget
 import de.jrpie.android.launcher.widgets.Widget
 import de.jrpie.android.launcher.widgets.WidgetPanel
+import eu.jonahbauer.android.preference.annotations.serializer.PreferenceExportSerializer
 import eu.jonahbauer.android.preference.annotations.serializer.PreferenceSerializationException
 import eu.jonahbauer.android.preference.annotations.serializer.PreferenceSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.json.JSONArray
+import org.json.JSONObject
 
 
 @Suppress("UNCHECKED_CAST")
@@ -58,6 +63,112 @@ class SetWidgetPanelSerializer :
     override fun deserialize(value: java.util.Set<java.lang.String>?): java.util.Set<WidgetPanel>? {
         return value?.map(java.lang.String::toString)?.map(WidgetPanel::deserialize)
             ?.toHashSet() as? java.util.Set<WidgetPanel>
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
+class SetAbstractAppInfoExportSerializer :
+    PreferenceExportSerializer<java.util.Set<AbstractAppInfo>?, JSONArray?> {
+    @Throws(PreferenceSerializationException::class)
+    override fun export(value: java.util.Set<AbstractAppInfo>?): JSONArray? {
+        return value?.let { set -> JSONArray(set.map { JSONObject(it.serialize()) }) }
+    }
+
+    @Throws(PreferenceSerializationException::class)
+    override fun restore(value: JSONArray?): java.util.Set<AbstractAppInfo>? {
+        if (value == null) return null
+        return (0 until value.length())
+            .map { AbstractAppInfo.deserialize(value.getJSONObject(it).toString()) }
+            .toHashSet() as? java.util.Set<AbstractAppInfo>
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
+class SetPinnedShortcutInfoExportSerializer :
+    PreferenceExportSerializer<java.util.Set<PinnedShortcutInfo>?, JSONArray?> {
+    @Throws(PreferenceSerializationException::class)
+    override fun export(value: java.util.Set<PinnedShortcutInfo>?): JSONArray? {
+        return value?.let { set ->
+            JSONArray(set.map { JSONObject(Json.encodeToString<PinnedShortcutInfo>(it)) })
+        }
+    }
+
+    @Throws(PreferenceSerializationException::class)
+    override fun restore(value: JSONArray?): java.util.Set<PinnedShortcutInfo>? {
+        if (value == null) return null
+        return (0 until value.length())
+            .map { Json.decodeFromString<PinnedShortcutInfo>(value.getJSONObject(it).toString()) }
+            .toHashSet() as? java.util.Set<PinnedShortcutInfo>
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
+class MapAbstractAppInfoStringExportSerializer :
+    PreferenceExportSerializer<java.util.HashMap<AbstractAppInfo, String>?, JSONArray?> {
+    @Throws(PreferenceSerializationException::class)
+    override fun export(value: java.util.HashMap<AbstractAppInfo, String>?): JSONArray? {
+        return value?.let { map ->
+            JSONArray(map.map { (key, name) ->
+                JSONObject().put("key", JSONObject(key.serialize())).put("value", name)
+            })
+        }
+    }
+
+    @Throws(PreferenceSerializationException::class)
+    override fun restore(value: JSONArray?): java.util.HashMap<AbstractAppInfo, String>? {
+        if (value == null) return null
+        val map = java.util.HashMap<AbstractAppInfo, String>()
+        for (i in 0 until value.length()) {
+            val entry = value.getJSONObject(i)
+            map[AbstractAppInfo.deserialize(entry.getJSONObject("key").toString())] =
+                entry.getString("value")
+        }
+        return map
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
+class SetWidgetExportSerializer :
+    PreferenceExportSerializer<java.util.Set<Widget>?, JSONArray?> {
+    @Throws(PreferenceSerializationException::class)
+    override fun export(value: java.util.Set<Widget>?): JSONArray? {
+        // The appWidgetId of an AppWidget does not survive a backup,
+        // so AppWidgets are exported as BrokenWidgets keeping the original provider.
+        return value?.let { set ->
+            JSONArray(set.map {
+                JSONObject((if (it is AppWidget) BrokenWidget(it) else it).serialize())
+            })
+        }
+    }
+
+    @Throws(PreferenceSerializationException::class)
+    override fun restore(value: JSONArray?): java.util.Set<Widget>? {
+        if (value == null) return null
+        return (0 until value.length())
+            .map { Widget.deserialize(value.getJSONObject(it).toString()) }
+            .toHashSet() as? java.util.Set<Widget>
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
+class SetWidgetPanelExportSerializer :
+    PreferenceExportSerializer<java.util.Set<WidgetPanel>?, JSONArray?> {
+    @Throws(PreferenceSerializationException::class)
+    override fun export(value: java.util.Set<WidgetPanel>?): JSONArray? {
+        return value?.let { set -> JSONArray(set.map { JSONObject(it.serialize()) }) }
+    }
+
+    @Throws(PreferenceSerializationException::class)
+    override fun restore(value: JSONArray?): java.util.Set<WidgetPanel>? {
+        if (value == null) return null
+        return (0 until value.length())
+            .map { WidgetPanel.deserialize(value.getJSONObject(it).toString()) }
+            .toHashSet() as? java.util.Set<WidgetPanel>
     }
 }
 

--- a/app/src/main/java/de/jrpie/android/launcher/ui/settings/meta/SettingsFragmentMeta.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/settings/meta/SettingsFragmentMeta.kt
@@ -2,12 +2,15 @@ package de.jrpie.android.launcher.ui.settings.meta
 
 import android.app.AlertDialog
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import de.jrpie.android.launcher.BuildConfig
 import de.jrpie.android.launcher.R
@@ -16,9 +19,12 @@ import de.jrpie.android.launcher.databinding.SettingsMetaBinding
 import de.jrpie.android.launcher.getDeviceInfo
 import de.jrpie.android.launcher.openInBrowser
 import de.jrpie.android.launcher.openTutorial
+import de.jrpie.android.launcher.preferences.exportSettings
+import de.jrpie.android.launcher.preferences.importSettings
 import de.jrpie.android.launcher.preferences.resetPreferences
 import de.jrpie.android.launcher.ui.LegalInfoActivity
 import de.jrpie.android.launcher.ui.UIObject
+import org.json.JSONObject
 
 /**
  * The [SettingsFragmentMeta] is a used as a tab in the SettingsActivity.
@@ -31,6 +37,15 @@ import de.jrpie.android.launcher.ui.UIObject
 class SettingsFragmentMeta : Fragment(), UIObject {
 
     private lateinit var binding: SettingsMetaBinding
+
+    private val exportSettingsLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri -> uri?.let { exportSettings(it) } }
+
+    private val importSettingsLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> uri?.let { importSettings(it) } }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -76,6 +91,25 @@ class SettingsFragmentMeta : Fragment(), UIObject {
                 .show()
         }
 
+
+        binding.settingsMetaButtonExportSettings.setOnClickListener {
+            exportSettingsLauncher.launch(getString(R.string.settings_meta_export_file_name))
+        }
+
+        // prompting for confirmation before overwriting settings
+        binding.settingsMetaButtonImportSettings.setOnClickListener {
+            AlertDialog.Builder(this.requireContext(), R.style.AlertDialogCustom)
+                .setTitle(getString(R.string.settings_meta_import))
+                .setMessage(getString(R.string.settings_meta_import_confirm))
+                .setPositiveButton(
+                    android.R.string.ok
+                ) { _, _ ->
+                    importSettingsLauncher.launch(arrayOf("application/json"))
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .show()
+        }
 
         // view code
         bindURL(binding.settingsMetaButtonViewCode, R.string.settings_meta_link_github)
@@ -143,5 +177,40 @@ class SettingsFragmentMeta : Fragment(), UIObject {
             copyToClipboard(requireContext(), deviceInfo)
         }
 
+    }
+
+    private fun exportSettings(uri: Uri) {
+        try {
+            val json = exportSettings(requireContext())
+            requireContext().contentResolver.openOutputStream(uri)?.use {
+                it.write(json.toString(2).toByteArray())
+            }
+        } catch (e: Exception) {
+            Toast.makeText(
+                requireContext(),
+                R.string.settings_meta_export_error,
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    private fun importSettings(uri: Uri) {
+        try {
+            val text = requireContext().contentResolver.openInputStream(uri)?.use {
+                it.readBytes().toString(Charsets.UTF_8)
+            } ?: throw IllegalStateException("Could not read $uri")
+            importSettings(requireContext(), JSONObject(text))
+            Toast.makeText(
+                requireContext(),
+                R.string.settings_meta_import_success,
+                Toast.LENGTH_LONG
+            ).show()
+        } catch (e: Exception) {
+            Toast.makeText(
+                requireContext(),
+                R.string.settings_meta_import_error,
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 }

--- a/app/src/main/java/de/jrpie/android/launcher/ui/widgets/BrokenWidgetView.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/ui/widgets/BrokenWidgetView.kt
@@ -1,0 +1,26 @@
+package de.jrpie.android.launcher.ui.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import de.jrpie.android.launcher.R
+import de.jrpie.android.launcher.databinding.WidgetBrokenBinding
+
+class BrokenWidgetView(
+    context: Context,
+    attrs: AttributeSet? = null,
+    val appWidgetId: Int,
+    packageName: String?
+) : ConstraintLayout(context, attrs) {
+
+    val binding: WidgetBrokenBinding =
+        WidgetBrokenBinding.inflate(LayoutInflater.from(context), this, true)
+
+    init {
+        packageName?.let {
+            binding.brokenWidgetText.text =
+                context.getString(R.string.widget_broken_text_package, it)
+        }
+    }
+}

--- a/app/src/main/java/de/jrpie/android/launcher/widgets/BrokenWidget.kt
+++ b/app/src/main/java/de/jrpie/android/launcher/widgets/BrokenWidget.kt
@@ -1,0 +1,64 @@
+package de.jrpie.android.launcher.widgets
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.view.View
+import de.jrpie.android.launcher.ui.widgets.BrokenWidgetView
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A placeholder for an [AppWidget] that could not be restored from a settings backup.
+ * The appWidgetId of the original widget is useless on restore (the app widget host
+ * allocation does not survive a backup), so the original provider is remembered instead,
+ * allowing the user to see what was there and bind a new widget in its place.
+ */
+@Serializable
+@SerialName("widget:broken")
+class BrokenWidget(
+    override var id: Int,
+    override var position: WidgetPosition,
+    override val panelId: Int,
+    override var allowInteraction: Boolean = false,
+    val packageName: String? = null,
+    val className: String? = null,
+    val user: Int? = null
+) : Widget() {
+
+    constructor(widget: AppWidget) : this(
+        widget.id,
+        widget.position,
+        widget.panelId,
+        false,
+        widget.packageName,
+        widget.className,
+        widget.user
+    )
+
+    override fun createView(activity: Activity): View {
+        return BrokenWidgetView(activity, null, id, packageName)
+    }
+
+    override fun findView(views: Sequence<View>): BrokenWidgetView? {
+        return views.mapNotNull { it as? BrokenWidgetView }.firstOrNull { it.appWidgetId == id }
+    }
+
+    override fun getPreview(context: Context): Drawable? {
+        return null
+    }
+
+    override fun getIcon(context: Context): Drawable? {
+        return null
+    }
+
+    override fun isConfigurable(context: Context): Boolean {
+        return false
+    }
+
+    override fun isReconfigurable(context: Context): Boolean {
+        return false
+    }
+
+    override fun configure(activity: Activity, requestCode: Int) {}
+}

--- a/app/src/main/res/layout/settings_meta.xml
+++ b/app/src/main/res/layout/settings_meta.xml
@@ -30,6 +30,20 @@
             android:text="@string/settings_meta_reset"
             android:textAllCaps="false" />
 
+        <Button
+            android:id="@+id/settings_meta_button_export_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_meta_export"
+            android:textAllCaps="false" />
+
+        <Button
+            android:id="@+id/settings_meta_button_import_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_meta_import"
+            android:textAllCaps="false" />
+
         <Space
             android:layout_width="match_parent"
             android:layout_height="64sp" />

--- a/app/src/main/res/layout/widget_broken.xml
+++ b/app/src/main/res/layout/widget_broken.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:longClickable="false"
+    tools:context=".ui.widgets.BrokenWidgetView">
+
+    <TextView
+        android:id="@+id/brokenWidgetText"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/widget_broken_text" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,6 +223,15 @@
 
     <string name="settings_meta_reset">Reset Settings</string>
     <string name="settings_meta_reset_confirm">You are going to discard all your preferences. Continue?</string>
+    <string name="settings_meta_export">Export Settings</string>
+    <string name="settings_meta_import">Import Settings</string>
+    <string name="settings_meta_import_confirm">Importing settings will overwrite your current preferences. Continue?</string>
+    <string name="settings_meta_export_file_name">ulauncher-settings.json</string>
+    <string name="settings_meta_export_error">Could not export settings.</string>
+    <string name="settings_meta_import_error">Could not import settings. The file is not a valid settings backup.</string>
+    <string name="settings_meta_import_success">Settings imported successfully.</string>
+    <string name="widget_broken_text">This widget could not be restored from the backup. Replace it via the widget settings.</string>
+    <string name="widget_broken_text_package">The widget from %1$s could not be restored from the backup. Replace it via the widget settings.</string>
 
     <string name="settings_meta_view_code">View source code</string>
     <string name="settings_meta_report_bug">Report a bug</string>

--- a/app/src/test/java/de/jrpie/android/launcher/preferences/BackupTest.kt
+++ b/app/src/test/java/de/jrpie/android/launcher/preferences/BackupTest.kt
@@ -1,0 +1,103 @@
+package de.jrpie.android.launcher.preferences
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class BackupTest {
+
+    @Test
+    fun `remapUserIds rewrites user fields in nested objects`() {
+        val json = JSONObject(
+            """
+            {
+                "apps.favorites": [
+                    {"type": "app", "packageName": "com.example.a", "activityName": null, "user": 10},
+                    {"type": "app", "packageName": "com.example.b", "activityName": null, "user": 0}
+                ],
+                "action.up": {"type": "action:app", "app": {"packageName": "com.example.c", "user": 10}}
+            }
+            """
+        )
+
+        remapUserIds(json, mapOf(10 to 11, 0 to 0))
+
+        val favorites = json.getJSONArray("apps.favorites")
+        assertEquals(11, favorites.getJSONObject(0).getInt("user"))
+        assertEquals(0, favorites.getJSONObject(1).getInt("user"))
+        assertEquals(11, json.getJSONObject("action.up").getJSONObject("app").getInt("user"))
+    }
+
+    @Test
+    fun `remapUserIds rewrites user fields in map entry keys`() {
+        val json = JSONObject(
+            """
+            {
+                "apps.custom_names": [
+                    {"key": {"type": "app", "packageName": "com.example.a", "user": 10}, "value": "Custom"}
+                ]
+            }
+            """
+        )
+
+        remapUserIds(json, mapOf(10 to 12))
+
+        val entry = json.getJSONArray("apps.custom_names").getJSONObject(0)
+        assertEquals(12, entry.getJSONObject("key").getInt("user"))
+        assertEquals("Custom", entry.getString("value"))
+    }
+
+    @Test
+    fun `remapUserIds leaves unmapped user ids unchanged`() {
+        val json = JSONObject("""{"widget": {"user": 42, "id": 7}}""")
+
+        remapUserIds(json, mapOf(10 to 11))
+
+        assertEquals(42, json.getJSONObject("widget").getInt("user"))
+        assertEquals(7, json.getJSONObject("widget").getInt("id"))
+    }
+
+    @Test
+    fun `remapUserIds ignores non integer user fields`() {
+        val json = JSONObject("""{"entry": {"user": "not an id"}}""")
+
+        remapUserIds(json, mapOf(10 to 11))
+
+        assertEquals("not an id", json.getJSONObject("entry").getString("user"))
+    }
+
+    @Test
+    fun `remapUserIds does not rewrite values of fields not named user`() {
+        val json = JSONObject("""{"entry": {"id": 10, "panelId": 10}}""")
+
+        remapUserIds(json, mapOf(10 to 11))
+
+        assertEquals(10, json.getJSONObject("entry").getInt("id"))
+        assertEquals(10, json.getJSONObject("entry").getInt("panelId"))
+    }
+
+    @Test
+    fun `remapUserIds descends into arrays of arrays`() {
+        val json = JSONObject()
+        json.put("nested", JSONArray(listOf(JSONArray(listOf(JSONObject("""{"user": 10}"""))))))
+
+        remapUserIds(json, mapOf(10 to 11))
+
+        assertEquals(
+            11,
+            json.getJSONArray("nested").getJSONArray(0).getJSONObject(0).getInt("user")
+        )
+    }
+
+    @Test
+    fun `migrateBackupToNewVersion rejects versions without a migration path`() {
+        assertThrows(BackupVersionException::class.java) {
+            migrateBackupToNewVersion(JSONObject(), UNKNOWN_PREFERENCE_VERSION)
+        }
+        assertThrows(BackupVersionException::class.java) {
+            migrateBackupToNewVersion(JSONObject(), 100)
+        }
+    }
+}

--- a/app/src/test/java/de/jrpie/android/launcher/preferences/serialization/ExportSerializersTest.kt
+++ b/app/src/test/java/de/jrpie/android/launcher/preferences/serialization/ExportSerializersTest.kt
@@ -1,0 +1,117 @@
+@file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
+package de.jrpie.android.launcher.preferences.serialization
+
+import de.jrpie.android.launcher.apps.AbstractAppInfo
+import de.jrpie.android.launcher.apps.AppInfo
+import de.jrpie.android.launcher.apps.PinnedShortcutInfo
+import de.jrpie.android.launcher.widgets.AppWidget
+import de.jrpie.android.launcher.widgets.BrokenWidget
+import de.jrpie.android.launcher.widgets.ClockWidget
+import de.jrpie.android.launcher.widgets.Widget
+import de.jrpie.android.launcher.widgets.WidgetPanel
+import de.jrpie.android.launcher.widgets.WidgetPosition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExportSerializersTest {
+
+    @Test
+    fun `app info sets export as json objects and round trip`() {
+        val serializer = SetAbstractAppInfoExportSerializer()
+        val set = hashSetOf<AbstractAppInfo>(
+            AppInfo("com.example.app", "com.example.app.MainActivity", 0),
+            PinnedShortcutInfo("id1", "com.example.shortcut", "com.example.shortcut.Activity", 10)
+        )
+
+        val json = serializer.export(set as java.util.Set<AbstractAppInfo>)!!
+
+        assertEquals(2, json.length())
+        // real nested JSON, not strings containing JSON
+        (0 until json.length()).forEach { i -> json.getJSONObject(i) }
+
+        assertEquals(set, serializer.restore(json))
+    }
+
+    @Test
+    fun `custom name map exports keys as json objects and round trips`() {
+        val serializer = MapAbstractAppInfoStringExportSerializer()
+        val map = hashMapOf<AbstractAppInfo, String>(
+            AppInfo("com.example.app", null, 0) as AbstractAppInfo to "Custom Name"
+        )
+
+        val json = serializer.export(map)!!
+
+        assertEquals(1, json.length())
+        assertEquals("Custom Name", json.getJSONObject(0).getString("value"))
+        assertEquals("com.example.app", json.getJSONObject(0).getJSONObject("key").getString("packageName"))
+
+        assertEquals(map, serializer.restore(json))
+    }
+
+    @Test
+    fun `app widgets are exported as broken widgets`() {
+        val serializer = SetWidgetExportSerializer()
+        val set = hashSetOf<Widget>(
+            AppWidget(
+                42, WidgetPosition(1, 2, 3, 4), WidgetPanel.HOME.id, false,
+                "com.example.app", "com.example.app.WidgetProvider", 0
+            ),
+            ClockWidget(-5, WidgetPosition(0, 0, 10, 4), WidgetPanel.HOME.id)
+        )
+
+        val json = serializer.export(set as java.util.Set<Widget>)!!
+        val types = (0 until json.length()).map { json.getJSONObject(it).getString("type") }
+
+        assertTrue("AppWidget must be exported as BrokenWidget", "widget:broken" in types)
+        assertTrue("internal widgets must be exported unchanged", "widget:clock" in types)
+
+        val restored = serializer.restore(json)!!
+        val broken = restored.filterIsInstance<BrokenWidget>().single()
+        assertEquals(42, broken.id)
+        assertEquals("com.example.app", broken.packageName)
+        assertEquals("com.example.app.WidgetProvider", broken.className)
+        assertEquals(0, broken.user)
+        assertTrue(restored.filterIsInstance<ClockWidget>().single().id == -5)
+    }
+
+    @Test
+    fun `widget panels round trip`() {
+        val serializer = SetWidgetPanelExportSerializer()
+        val set = hashSetOf(WidgetPanel(3, "My Panel"))
+
+        val json = serializer.export(set as java.util.Set<WidgetPanel>)!!
+
+        assertEquals("My Panel", json.getJSONObject(0).getString("label"))
+        assertEquals(set, serializer.restore(json))
+    }
+
+    @Test
+    fun `export serializers pass null through`() {
+        assertNull(SetAbstractAppInfoExportSerializer().export(null))
+        assertNull(SetAbstractAppInfoExportSerializer().restore(null))
+        assertNull(MapAbstractAppInfoStringExportSerializer().export(null))
+        assertNull(MapAbstractAppInfoStringExportSerializer().restore(null))
+        assertNull(SetWidgetExportSerializer().export(null))
+        assertNull(SetWidgetExportSerializer().restore(null))
+        assertNull(SetWidgetPanelExportSerializer().export(null))
+        assertNull(SetWidgetPanelExportSerializer().restore(null))
+        assertNull(SetPinnedShortcutInfoExportSerializer().export(null))
+        assertNull(SetPinnedShortcutInfoExportSerializer().restore(null))
+    }
+
+    @Test
+    fun `pinned shortcut sets round trip`() {
+        val serializer = SetPinnedShortcutInfoExportSerializer()
+        val set = hashSetOf(
+            PinnedShortcutInfo("shortcut1", "com.example.app", "com.example.app.Activity", 10)
+        )
+
+        val json = serializer.export(set as java.util.Set<PinnedShortcutInfo>)!!
+
+        assertEquals("shortcut1", json.getJSONObject(0).getString("id"))
+        assertEquals(set, serializer.restore(json))
+    }
+}

--- a/docs/changes-fork.md
+++ b/docs/changes-fork.md
@@ -23,6 +23,7 @@ The decision to create a hard fork was made two years later.-->
 - Option to rename apps
 - Option to hide apps
 - Favorite apps
+- Settings can be exported to and imported from a JSON file (backup / restore)
 - New actions:
   - Toggle Torch
   - Lock screen

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -283,10 +283,10 @@ Saves all settings — preferences, gesture bindings, favorite / hidden / rename
 
 Note that some information only makes sense on the device the backup was created on:
 
-- App widgets cannot be restored directly, as Android requires user interaction to add a widget.
+* App widgets cannot be restored directly, as Android requires user interaction to add a widget.
   Instead, a placeholder is restored in the widget's place, showing which app the widget belonged to,
   so it can be re-added via the widget settings.
-- Apps from the work profile or private space are matched to the corresponding profile on the new device.
+* Apps from the work profile or private space are matched to the corresponding profile on the new device.
   Apps that are not installed on the new device are restored but won't be usable until the app is installed.
 
 **type:**&nbsp;`button`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -271,3 +271,29 @@ Remove the top status bar from the home screen.
 Remove the navigation bar from the home screen. Enabling this setting may make it difficult to use the device if gestures are not set up properly.
 
 **type:**&nbsp;`toggle`
+
+## Backup
+
+Settings can be backed up to a file and restored later, also on a different device.
+The corresponding buttons are found in the *meta* tab of the settings.
+
+### Export Settings
+
+Saves all settings — preferences, gesture bindings, favorite / hidden / renamed apps, pinned shortcuts and widgets — to a JSON file.
+
+Note that some information only makes sense on the device the backup was created on:
+
+- App widgets cannot be restored directly, as Android requires user interaction to add a widget.
+  Instead, a placeholder is restored in the widget's place, showing which app the widget belonged to,
+  so it can be re-added via the widget settings.
+- Apps from the work profile or private space are matched to the corresponding profile on the new device.
+  Apps that are not installed on the new device are restored but won't be usable until the app is installed.
+
+**type:**&nbsp;`button`
+
+### Import Settings
+
+Restores settings from a file created with *Export Settings*, overwriting the current settings.
+Files created by a newer version of µLauncher than the one installed are rejected.
+
+**type:**&nbsp;`button`

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -21,6 +21,13 @@ However, &mu;Launcher [gestures](/docs/actions-and-gestures/) can not be execute
 
 [^1]: However, it is technically not an app widget and cannot be used with other launchers.
 
+## Widgets and settings backup
+
+When [exporting the settings](/docs/settings/#backup), app widgets cannot be included directly,
+as Android requires user interaction to add a widget.
+When importing a backup, a placeholder is shown in the widget's place instead,
+showing which app the original widget belonged to so it can be re-added via `Settings > Manage Widgets`.
+
 # Widget Panels
 
 Widget panels can contain widgets that are not needed on the home screen.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 activity = "1.11.0"
 activity-ktx = "1.11.0"
 agp = "8.13.0"
-android-preference-annotations = "1.1.2"
+android-preference-annotations = "1.2.0-SNAPSHOT"
 appcompat = "1.7.1"
 constraintlayout = "2.2.1"
 core-ktx = "1.17.0"
@@ -42,6 +42,7 @@ jonahbauer-android-preference-annotations = { group = "eu.jonahbauer", name = "a
 
 # Testing dependencies
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+json = { group = "org.json", name = "json", version = "20220924" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,13 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        // for testing locally built android-preference-annotations
+        // (./gradlew publishToMavenLocal -x signJavaPublication in that repo)
+        mavenLocal {
+            content {
+                includeGroup("eu.jonahbauer")
+            }
+        }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
Closes #79.

Adds export/import of all settings to a JSON file, with buttons in the *meta* tab of the settings. This implements the design discussed for #79 (generating the export/import in the preference-annotations library rather than hardcoding it).

## Background

Still hoping to resolve the legendary #79. I opened an earlier attempt in #285, but it hardcoded the export import logic directly in the launcher, which didn't fit the constraints @jrpie wanted for the feature. We worked through the design in a bit in a DM thread and this PR implements what we landed on. For anyone else following along, here are the constraints that shaped it:

- **Generate, don't hardcode.** Instead of hand-writing serialization in the launcher (the #285 approach), the export/import is *generated* in the `preference-annotations` library from an `export` flag on `@Preference`, so it stays in sync with the config schema automatically.
- **Gestures included.** Gesture → `Action` bindings are written into the same JSON file, keyed by gesture id.
- **Versioned and forward-safe.** The backup embeds the preference version; imports reject backups from a *newer* version, and older ones reuse the existing migration path rather than duplicating migration logic.
- **Cross-device restore.** Export a user-id → profile-type map (main / work profile / private space) so `user` fields remap to the matching profile when restoring on a different device.
- **Widgets as placeholders.** App widgets can't be restored directly (the app-widget host allocation doesn't survive a backup), so on export they convert to an internal `BrokenWidget` type mirroring how the built-in clock/debug widgets work and come back as placeholders naming the original app.
- **`internal` group excluded** from export (started / version_code).

The library-side change is intentionally being kept on my fork and out of an upstream PR until this launcher side is polished and working end-to-end.

## ⚠️ Depends on a preference-annotations change

This branch depends on `eu.jonahbauer:android-preference-annotations:1.2.0-SNAPSHOT`, which adds `export` / `exportSerializer` to `@Preference` and generates `exportPreferences()` / `importPreferences(JSONObject)`. That change lives on my fork, branch `feature/preference-export`:

  https://github.com/wassupluke/android-preference-annotations/tree/feature/preference-export

To build this branch, publish that library to your local Maven repo:

    git clone -b feature/preference-export https://github.com/wassupluke/android-preference-annotations
    cd android-preference-annotations
    ./gradlew publishToMavenLocal -x signJavaPublication

`settings.gradle.kts` pulls the dependency from `mavenLocal` and `libs.versions.toml` points at the snapshot. **Those two edits are temporary scaffolding** they'll be dropped / bumped to a released version before merge, once the library change has a proper home.

## What's included

- **Config schema:** every non-internal, non-void preference is flagged `export = true`; the `internal` group (started / version_code) is excluded on purpose.
- **`Backup.kt`** assembles the backup document:
  - preferences (via the generated `exportPreferences` / `importPreferences`), keyed by preference key,
  - the `Action` bound to each `Gesture`, keyed by gesture id,
  - `_version`: the `PREFERENCE_VERSION` the backup was made with. Import rejects backups from a newer version and routes older ones through `migrateBackupToNewVersion` (a counterpart to `migratePreferencesToNewVersion`; no cases yet, since backups didn't exist before v101),
  - `_users`: a user-id → profile-type (main / work / private space) map, so `user` fields can be remapped to the matching profile when restoring on a different device.
- **Export serializers** (`PreferenceSerializers.kt`) for the five custom preference types, emitting real nested JSON rather than JSON-in-strings.
- **`BrokenWidget`** app widgets can't be restored directly (the app-widget host allocation doesn't survive a backup), so on export each `AppWidget` is converted to a `BrokenWidget` placeholder that remembers the original provider. On restore it shows which app the widget belonged to so the user can re-add it. Built-in widgets (clock, debug) pass through unchanged.
- **UI:** Export / Import buttons in the meta tab, using SAF (`CreateDocument` / `OpenDocument`); import is behind a confirmation dialog and reports success / failure via toast.
- **Tests:** round-trip tests for the export serializers (incl. the AppWidget → BrokenWidget conversion) and `remapUserIds` / version-migration behavior. Needs the real `org.json` as a test dependency, since the android.jar unit-test stubs throw.
- **Docs:** backup section in `docs/settings.md`, widget-backup note in `docs/widgets.md`, changelog entry in `docs/changes-fork.md`.

## Testing

- Ran the new unit tests (`ExportSerializersTest`, `BackupTest`).
- Manual round-trip on emulator and on a physical device: export → *Reset Settings* → import restores the full configuration, and the imported state survives a force-stop and restart.
- Verified that app widgets come back as `BrokenWidget` placeholders naming the original app, and that work-profile / private-space apps are remapped to the matching profile on the target device.

## Notes

- Apps not installed on the target device are restored but unusable until installed.
- Only the English strings are added, per the translation workflow.
