### PR TITLE
Fix low-contrast popup menus and dropdowns

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,13 +6,24 @@
     <color name="finnmglasTheme_text_color">#fff</color>
 
     <color name="darkTheme_background_color">#000</color>
-    <color name="darkTheme_card_background_color">#242424</color>
+    <color name="darkTheme_card_background_color">#181818</color>
     <color name="darkTheme_accent_color">#444</color>
     <color name="darkTheme_text_color">#fff</color>
 
     <color name="lightTheme_background_color">#fff</color>
-    <color name="lightTheme_card_background_color">#ffffff</color>
+    <color name="lightTheme_card_background_color">#dbdbdb</color>
     <color name="lightTheme_accent_color">#9999ff</color>
     <color name="lightTheme_text_color">#000</color>
+
+    <color name="greenTheme_accent_color">#0a0</color>
+    <color name="greenTheme_text_color">#0f0</color>
+    <color name="greenTheme_card_background_color">#002400</color>
+
+
+    <color name="amberTheme_accent_color">#aa6a00</color>
+    <color name="amberTheme_text_color">#ffb000</color>
+    <color name="amberTheme_card_background_color">#241800</color>
+
+
 </resources>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="finnmglasTheme_background_color">#252827</color>
+    <color name="finnmglasTheme_card_background_color">#3c3f3e</color>
     <color name="finnmglasTheme_accent_color">#5555ff</color>
     <color name="finnmglasTheme_text_color">#fff</color>
 
     <color name="darkTheme_background_color">#000</color>
+    <color name="darkTheme_card_background_color">#242424</color>
     <color name="darkTheme_accent_color">#444</color>
     <color name="darkTheme_text_color">#fff</color>
 
     <color name="lightTheme_background_color">#fff</color>
+    <color name="lightTheme_card_background_color">#ffffff</color>
     <color name="lightTheme_accent_color">#9999ff</color>
     <color name="lightTheme_text_color">#000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,9 +21,11 @@
 
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
         <item name="colorButtonNormal">?colorAccent</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/finnmglasTheme_card_background_color</item>
 
-        <!--<item name="android:popupMenuStyle">@style/PopupMenuCustom</item>-->
+        <item name="android:popupMenuStyle">@style/PopupMenuCustom</item>
+        <item name="android:spinnerStyle">@style/SpinnerCustom</item>
+        <item name="spinnerStyle">@style/SpinnerCustom</item>
 
         <item name="android:windowDisablePreview">true</item>
         <item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
@@ -40,7 +42,7 @@
         <item name="colorPrimaryDark">@color/darkTheme_background_color</item>
         <item name="colorAccent">@color/darkTheme_accent_color</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/darkTheme_card_background_color</item>
         <item name="android:textColor">@color/darkTheme_text_color</item>
     </style>
 
@@ -50,7 +52,7 @@
         <item name="colorAccent">#0f0</item>
         <item name="android:buttonStyle">@style/buttonBlackText</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/darkTheme_card_background_color</item>
         <item name="android:textColor">#0f0</item>
     </style>
 
@@ -60,7 +62,7 @@
         <item name="colorAccent">#FFB000</item>
         <item name="android:buttonStyle">@style/buttonBlackText</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/darkTheme_card_background_color</item>
         <item name="android:textColor">#ffb000</item>
     </style>
 
@@ -70,7 +72,7 @@
         <item name="colorPrimaryDark">@color/finnmglasTheme_background_color</item>
         <item name="colorAccent">@color/finnmglasTheme_accent_color</item>
         <item name="android:colorBackground">@color/finnmglasTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/finnmglasTheme_card_background_color</item>
         <item name="android:textColor">@color/finnmglasTheme_text_color</item>
     </style>
 
@@ -79,7 +81,7 @@
         <item name="colorPrimaryDark">@color/lightTheme_background_color</item>
         <item name="colorAccent">@color/lightTheme_accent_color</item>
         <item name="android:colorBackground">@color/lightTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/cardview_light_background</item>
+        <item name="cardBackgroundColor">@color/lightTheme_card_background_color</item>
         <item name="android:textColor">@color/lightTheme_text_color</item>
     </style>
 
@@ -89,7 +91,7 @@
         <item name="colorPrimaryDark">@color/material_dynamic_primary50</item>
         <item name="colorAccent">@color/material_dynamic_tertiary50</item>
         <item name="android:colorBackground">@color/material_dynamic_neutral10</item>
-        <item name="cardBackgroundColor">@color/cardview_dark_background</item>
+        <item name="cardBackgroundColor">@color/material_dynamic_neutral20</item>
         <item name="android:textColor">@color/material_dynamic_neutral_variant90</item>
     </style>
 
@@ -144,7 +146,12 @@
     </style>
 
     <style name="PopupMenuCustom" parent="@android:style/Widget.PopupMenu" tools:keep="@style/PopupMenuCustom">
-        <item name="android:popupBackground">#252827</item>
+        <item name="android:popupBackground">?attr/cardBackgroundColor</item>
+        <item name="android:popupElevation">8dp</item>
+    </style>
+
+    <style name="SpinnerCustom" parent="@style/Widget.AppCompat.Spinner" tools:keep="@style/SpinnerCustom">
+        <item name="android:popupBackground">?attr/cardBackgroundColor</item>
     </style>
 
     <style name="AlertDialogCustom" parent="Theme.AppCompat.Light.Dialog.Alert">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,21 +49,21 @@
     <style name="colorThemeGreen">
         <item name="colorPrimary">@color/darkTheme_background_color</item>
         <item name="colorPrimaryDark">@color/darkTheme_background_color</item>
-        <item name="colorAccent">#0f0</item>
+        <item name="colorAccent">@color/greenTheme_accent_color</item>
         <item name="android:buttonStyle">@style/buttonBlackText</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/darkTheme_card_background_color</item>
-        <item name="android:textColor">#0f0</item>
+        <item name="cardBackgroundColor">@color/greenTheme_card_background_color</item>
+        <item name="android:textColor">@color/greenTheme_text_color</item>
     </style>
 
     <style name="colorThemeAmber">
         <item name="colorPrimary">@color/darkTheme_background_color</item>
         <item name="colorPrimaryDark">@color/darkTheme_background_color</item>
-        <item name="colorAccent">#FFB000</item>
+        <item name="colorAccent">@color/amberTheme_accent_color</item>
         <item name="android:buttonStyle">@style/buttonBlackText</item>
         <item name="android:colorBackground">@color/darkTheme_background_color</item>
-        <item name="cardBackgroundColor">@color/darkTheme_card_background_color</item>
-        <item name="android:textColor">#ffb000</item>
+        <item name="cardBackgroundColor">@color/amberTheme_card_background_color</item>
+        <item name="android:textColor">@color/amberTheme_text_color</item>
     </style>
 
 


### PR DESCRIPTION
Long-press menus and Settings dropdowns were nearly invisible against the app list/settings background on every color theme except Light (the dark shadow works nicely here but not on the dark themes).

Added a lighter per-theme background color and applied it to both popup menus and dropdowns app-wide.

Verified on all six color themes. See screenshots.

Before
![ctxmenu_baseline_DARK.png](https://github.com/user-attachments/assets/85c6023f-cc4f-4f78-afe2-b8c3588fb121)

After
![ctxmenu_new_DARK.png](https://github.com/user-attachments/assets/660745e5-7975-4689-bece-299ff20c518c)

Before
![ctxmenu_baseline_DYNAMIC.png](https://github.com/user-attachments/assets/9a41dcf2-0841-4f6a-9211-2769f3ac12b1)

After
![ctxmenu_new_DYNAMIC.png](https://github.com/user-attachments/assets/462ac1c6-7d1c-4a82-96ed-3d0098e1a18e)

Before
![spinner_baseline_GREEN.png](https://github.com/user-attachments/assets/15ee508c-d6e0-4e7f-9c12-7af06768675a)

After
![spinner_new_GREEN.png](https://github.com/user-attachments/assets/e6a7f9e5-87ab-40dc-8756-6bbe854dccc7)







